### PR TITLE
tools: Add CLI helper

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@score_cli_helper//:cli_helper.bzl", "cli_helper")
 load("@score_cr_checker//:cr_checker.bzl", "copyright_checker")
 load("@score_dash_license_checker//:dash.bzl", "dash_license_checker")
 load("@score_docs_as_code//:docs.bzl", "docs")
@@ -52,12 +53,18 @@ dash_license_checker(
     visibility = ["//visibility:public"],
 )
 
+cli_helper(
+    name = "cli-help",
+    visibility = ["//visibility:public"],
+)
+
 # Add target for formatting checks
 use_format_targets()
 
 alias(
     name = "kvs_cpp",
     actual = "//src/cpp/src:kvs_cpp",
+    tags = ["cli_help=Build KVS CPP [build]"],
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -106,3 +106,5 @@ git_override(
     commit = "46923f5c4f302bd9feae0261588687aaf32e3c5c",
     remote = "https://github.com/eclipse-score/baselibs.git",
 )
+
+bazel_dep(name = "score_cli_helper", version = "0.1.2")

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ List all targets:
 bazel query //...
 ```
 
+List currated available targets with description:
+
+```bash
+bazel run //:help
+```
+
 Build selected target:
 
 ```bash


### PR DESCRIPTION
Add target //:help that lists currated bazel targets available.

Related: https://github.com/eclipse-score/inc_mw_per/issues/70