### PR TITLE
impl: change `flush_on_exit` APIs

### DIFF
--- a/src/rust/rust_kvs/examples/flush.rs
+++ b/src/rust/rust_kvs/examples/flush.rs
@@ -34,10 +34,10 @@ fn main() -> Result<(), ErrorCode> {
         {
             // Build KVS instance for given instance ID and temporary directory.
             let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
-            let kvs = builder.build()?;
+            let mut kvs = builder.build()?;
 
             // Disable flush on exit.
-            kvs.flush_on_exit(false);
+            kvs.set_flush_on_exit(FlushOnExit::No);
 
             // Set value - will be dropped on going out of scope.
             kvs.set_value("k1", "v1")?;
@@ -55,10 +55,10 @@ fn main() -> Result<(), ErrorCode> {
         {
             // Build KVS instance for given instance ID and temporary directory.
             let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
-            let kvs = builder.build()?;
+            let mut kvs = builder.build()?;
 
             // Explicitly enable flush on exit - this is the default.
-            kvs.flush_on_exit(true);
+            kvs.set_flush_on_exit(FlushOnExit::Yes);
 
             // Set value.
             kvs.set_value("k1", "v1")?;
@@ -76,10 +76,10 @@ fn main() -> Result<(), ErrorCode> {
         {
             // Build KVS instance for given instance ID and temporary directory.
             let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
-            let kvs = builder.build()?;
+            let mut kvs = builder.build()?;
 
             // Disable flush on exit.
-            kvs.flush_on_exit(false);
+            kvs.set_flush_on_exit(FlushOnExit::No);
 
             // Set value.
             kvs.set_value("k2", "v2")?;
@@ -94,8 +94,8 @@ fn main() -> Result<(), ErrorCode> {
             let builder = KvsBuilder::<Kvs>::new(instance_id.clone())
                 .dir(dir_string)
                 .need_kvs(true);
-            let kvs = builder.build()?;
-            kvs.flush_on_exit(false);
+            let mut kvs = builder.build()?;
+            kvs.set_flush_on_exit(FlushOnExit::No);
 
             let k1_key = "k1";
             let k1_value = kvs.get_value(k1_key)?;

--- a/src/rust/rust_kvs/examples/snapshots.rs
+++ b/src/rust/rust_kvs/examples/snapshots.rs
@@ -18,8 +18,8 @@ fn main() -> Result<(), ErrorCode> {
 
         // Build KVS instance for given instance ID and temporary directory.
         let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
-        let kvs = builder.build()?;
-        kvs.flush_on_exit(false);
+        let mut kvs = builder.build()?;
+        kvs.set_flush_on_exit(FlushOnExit::No);
 
         let max_count = Kvs::snapshot_max_count() as u32;
         println!("Max snapshot count: {max_count:?}");
@@ -40,8 +40,8 @@ fn main() -> Result<(), ErrorCode> {
 
         // Build KVS instance for given instance ID and temporary directory.
         let builder = KvsBuilder::<Kvs>::new(instance_id.clone()).dir(dir_string.clone());
-        let kvs = builder.build()?;
-        kvs.flush_on_exit(false);
+        let mut kvs = builder.build()?;
+        kvs.set_flush_on_exit(FlushOnExit::No);
 
         let max_count = Kvs::snapshot_max_count() as u32;
         let counter_key = "counter";

--- a/src/rust/rust_kvs/src/kvs_api.rs
+++ b/src/rust/rust_kvs/src/kvs_api.rs
@@ -89,6 +89,16 @@ impl From<bool> for OpenNeedKvs {
     }
 }
 
+/// Flush on exit mode.
+#[derive(Clone, Debug, PartialEq)]
+pub enum FlushOnExit {
+    /// Do not flush on exit.
+    No,
+
+    /// Flush on exit.
+    Yes,
+}
+
 pub trait KvsApi {
     fn open(
         instance_id: InstanceId,
@@ -116,7 +126,8 @@ pub trait KvsApi {
         value: J,
     ) -> Result<(), ErrorCode>;
     fn remove_key(&self, key: &str) -> Result<(), ErrorCode>;
-    fn flush_on_exit(&self, flush_on_exit: bool);
+    fn flush_on_exit(&self) -> FlushOnExit;
+    fn set_flush_on_exit(&mut self, flush_on_exit: FlushOnExit);
     fn flush(&self) -> Result<(), ErrorCode>;
     fn snapshot_count(&self) -> usize;
     fn snapshot_max_count() -> usize

--- a/src/rust/rust_kvs/src/kvs_builder.rs
+++ b/src/rust/rust_kvs/src/kvs_builder.rs
@@ -115,7 +115,7 @@ impl<T: KvsApi> KvsBuilder<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::kvs_api::{OpenNeedDefaults, OpenNeedKvs, SnapshotId};
+    use crate::kvs_api::{FlushOnExit, OpenNeedDefaults, OpenNeedKvs, SnapshotId};
     use crate::kvs_value::KvsValue;
     use std::path::PathBuf;
 
@@ -211,7 +211,11 @@ mod tests {
             unimplemented!()
         }
 
-        fn flush_on_exit(&self, _flush_on_exit: bool) {
+        fn flush_on_exit(&self) -> FlushOnExit {
+            unimplemented!()
+        }
+
+        fn set_flush_on_exit(&mut self, _flush_on_exit: FlushOnExit) {
             unimplemented!()
         }
 

--- a/src/rust/rust_kvs/src/kvs_mock.rs
+++ b/src/rust/rust_kvs/src/kvs_mock.rs
@@ -10,6 +10,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::error_code::ErrorCode;
+use crate::kvs_api::FlushOnExit;
 use crate::kvs_api::KvsApi;
 use crate::kvs_api::SnapshotId;
 use crate::kvs_value::{KvsMap, KvsValue};
@@ -42,7 +43,10 @@ impl KvsApi for MockKvs {
             fail: false,
         })
     }
-    fn flush_on_exit(&self, _flush_on_exit: bool) {}
+    fn flush_on_exit(&self) -> FlushOnExit {
+        FlushOnExit::No
+    }
+    fn set_flush_on_exit(&mut self, _flush_on_exit: FlushOnExit) {}
     fn reset(&self) -> Result<(), ErrorCode> {
         if self.fail {
             return Err(ErrorCode::UnmappedError);

--- a/src/rust/rust_kvs/src/lib.rs
+++ b/src/rust/rust_kvs/src/lib.rs
@@ -149,7 +149,9 @@ pub type Kvs = kvs::GenericKvs<json_backend::JsonBackend>;
 pub mod prelude {
     pub use crate::error_code::ErrorCode;
     pub use crate::kvs::GenericKvs;
-    pub use crate::kvs_api::{InstanceId, KvsApi, OpenNeedDefaults, OpenNeedKvs, SnapshotId};
+    pub use crate::kvs_api::{
+        FlushOnExit, InstanceId, KvsApi, OpenNeedDefaults, OpenNeedKvs, SnapshotId,
+    };
     pub use crate::kvs_builder::KvsBuilder;
     pub use crate::kvs_value::{KvsMap, KvsValue};
     pub use crate::Kvs;

--- a/src/rust/rust_kvs/tests/cit_persistency.rs
+++ b/src/rust/rust_kvs/tests/cit_persistency.rs
@@ -100,13 +100,13 @@ fn cit_persistency_flush_on_exit_disabled_drop_data() -> Result<(), ErrorCode> {
 
     {
         // First KVS run.
-        let kvs = Kvs::open(
+        let mut kvs = Kvs::open(
             InstanceId(0),
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
         )?;
-        kvs.flush_on_exit(false);
+        kvs.set_flush_on_exit(FlushOnExit::No);
 
         // Set values.
         for (key, value) in kv_values.iter() {
@@ -158,13 +158,13 @@ fn cit_persistency_flush_on_exit_disabled_manual_flush() -> Result<(), ErrorCode
 
     {
         // First KVS run.
-        let kvs = Kvs::open(
+        let mut kvs = Kvs::open(
             InstanceId(0),
             OpenNeedDefaults::Optional,
             OpenNeedKvs::Optional,
             Some(dir_string.clone()),
         )?;
-        kvs.flush_on_exit(false);
+        kvs.set_flush_on_exit(FlushOnExit::No);
 
         // Set values.
         for (key, value) in kv_values.iter() {

--- a/tests/rust_test_scenarios/src/test_basic.rs
+++ b/tests/rust_test_scenarios/src/test_basic.rs
@@ -1,4 +1,4 @@
-use rust_kvs::prelude::*;
+use rust_kvs::{kvs_api::FlushOnExit, prelude::*};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use test_scenarios_rust::scenario::Scenario;
@@ -46,9 +46,14 @@ impl Scenario for BasicScenario {
         }
 
         // Create KVS.
-        let kvs: Kvs = builder.build().unwrap();
+        let mut kvs: Kvs = builder.build().unwrap();
         if let Some(flag) = params.flush_on_exit {
-            kvs.flush_on_exit(flag);
+            let mode = if flag {
+                FlushOnExit::Yes
+            } else {
+                FlushOnExit::No
+            };
+            kvs.set_flush_on_exit(mode);
         }
 
         // Simple set/get.


### PR DESCRIPTION
- Replaced `flush_on_exit` setter with `set_flush_on_exit`.
- Added `flush_on_exit` getter.
- Replaced unnamed boolean with `FlushOnExit` enum.