### PR TITLE
Add score_python_basics bazel MODULE

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -70,6 +70,8 @@ git_override(
     remote = "https://github.com/eclipse-score/docs-as-code.git",
 )
 
+# Provides, pytest & venv
+bazel_dep(name = "score_python_basics", version = "0.3.4")
 bazel_dep(name = "score_platform", version = "0.3.0")
 bazel_dep(name = "score_process", version = "1.1.0")
 


### PR DESCRIPTION
Because of https://github.com/eclipse-score/inc_mw_per/blob/main/BUILD#L24 using docs() from "@score_docs_as_code//:docs.bzl" and score_docs_as_code deps on "score_python_basics"