### PR TITLE
impl: Fix `open_kvs` error propagation

### DIFF
--- a/src/rust/rust_kvs/src/kvs.rs
+++ b/src/rust/rust_kvs/src/kvs.rs
@@ -135,7 +135,9 @@ impl<J: KvsBackend> GenericKvs<J> {
                 Ok(map)
             }
             Err(e) => {
-                if need_file.into() == OpenKvsNeedFile::Required {
+                // Propagate error if file was required or other error happened.
+                if need_file.into() == OpenKvsNeedFile::Required || e != ErrorCode::KvsFileReadError
+                {
                     eprintln!("error: file {filename:?} could not be read: {e:?}");
                     Err(e)
                 } else {


### PR DESCRIPTION
It's allowed for file to be not found for other modes than `Required`. Other errors should still be propagated.