### PR TITLE
testing: improve test scenarios error handling

### DIFF
--- a/tests/rust_test_scenarios/src/cit/default_values.rs
+++ b/tests/rust_test_scenarios/src/cit/default_values.rs
@@ -18,9 +18,10 @@ impl Scenario for DefaultValues {
         let key = "test_number";
 
         // Create KVS instance with provided params.
-        let params = KvsParameters::from_json(input.as_ref().unwrap()).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
         {
-            let kvs = kvs_instance(params.clone()).unwrap();
+            let kvs = kvs_instance(params.clone()).expect("Failed to create KVS instance");
 
             // Get current value parameters.
             let value_is_default = to_str(&kvs.is_value_default(key));
@@ -30,12 +31,12 @@ impl Scenario for DefaultValues {
             info!(key, value_is_default, default_value, current_value);
 
             // Set value and check value parameters.
-            kvs.set_value(key, 432.1).unwrap();
+            kvs.set_value(key, 432.1).expect("Failed to set value");
         }
 
         // Flush and reopen KVS instance to ensure persistency.
         {
-            let kvs = kvs_instance(params).unwrap();
+            let kvs = kvs_instance(params).expect("Failed to create KVS instance");
 
             // Get current value parameters.
             let value_is_default = to_str(&kvs.is_value_default(key));
@@ -62,9 +63,10 @@ impl Scenario for RemoveKey {
         let key = "test_number";
 
         // Create KVS instance with provided params.
-        let params = KvsParameters::from_json(input.as_ref().unwrap()).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
         {
-            let kvs = kvs_instance(params.clone()).unwrap();
+            let kvs = kvs_instance(params.clone()).expect("Failed to create KVS instance");
 
             // Get value parameters before set.
             let value_is_default = to_str(&kvs.is_value_default(key));
@@ -74,7 +76,7 @@ impl Scenario for RemoveKey {
             info!(key, value_is_default, default_value, current_value);
 
             // Get value parameters after set.
-            kvs.set_value(key, 432.1).unwrap();
+            kvs.set_value(key, 432.1).expect("Failed to set value");
 
             // Get current value parameters.
             let value_is_default = to_str(&kvs.is_value_default(key));
@@ -84,7 +86,7 @@ impl Scenario for RemoveKey {
             info!(key, value_is_default, default_value, current_value);
 
             // Get value parameters after remove.
-            kvs.remove_key(key).unwrap();
+            kvs.remove_key(key).expect("Failed to remove key");
             let value_is_default = to_str(&kvs.is_value_default(key));
             let default_value = to_str(&kvs.get_default_value(key));
             let current_value = to_str(&kvs.get_value(key));
@@ -108,9 +110,10 @@ impl Scenario for ResetAllKeys {
         let num_values = 5;
 
         // Create KVS instance with provided params.
-        let params = KvsParameters::from_json(input.as_ref().unwrap()).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
         {
-            let kvs = kvs_instance(params.clone()).unwrap();
+            let kvs = kvs_instance(params.clone()).expect("Failed to create KVS instance");
 
             // List of keys and corresponding values.
             let mut key_values = Vec::new();
@@ -123,28 +126,35 @@ impl Scenario for ResetAllKeys {
             // Set non-default values.
             for (key, value) in key_values.iter() {
                 // Get value parameters before set.
-                let value_is_default = kvs.is_value_default(key).unwrap();
-                let current_value = kvs.get_value_as::<f64>(key).unwrap();
+                let value_is_default = kvs
+                    .is_value_default(key)
+                    .expect("Failed to check if default value");
+                let current_value = kvs.get_value_as::<f64>(key).expect("Failed to read value");
 
                 info!(key = key, value_is_default, current_value);
 
                 // Set value.
-                kvs.set_value(key.clone(), *value).unwrap();
+                kvs.set_value(key.clone(), *value)
+                    .expect("Failed to set value");
 
                 // Get value parameters after set.
-                let value_is_default = kvs.is_value_default(key).unwrap();
-                let current_value = kvs.get_value_as::<f64>(key).unwrap();
+                let value_is_default = kvs
+                    .is_value_default(key)
+                    .expect("Failed to check if default value");
+                let current_value = kvs.get_value_as::<f64>(key).expect("Failed to read value");
 
                 info!(key, value_is_default, current_value);
             }
 
             // Reset.
-            kvs.reset().unwrap();
+            kvs.reset().expect("Failed to reset KVS instance");
 
             // Get value parameters after reset.
             for (key, _) in key_values.iter() {
-                let value_is_default = kvs.is_value_default(key).unwrap();
-                let current_value = kvs.get_value_as::<f64>(key).unwrap();
+                let value_is_default = kvs
+                    .is_value_default(key)
+                    .expect("Failed to check if default value");
+                let current_value = kvs.get_value_as::<f64>(key).expect("Failed to read value");
 
                 info!(key, value_is_default, current_value);
             }
@@ -167,9 +177,10 @@ impl Scenario for ResetSingleKey {
         let reset_index = 2;
 
         // Create KVS instance with provided params.
-        let params = KvsParameters::from_json(input.as_ref().unwrap()).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
         {
-            let kvs = kvs_instance(params.clone()).unwrap();
+            let kvs = kvs_instance(params.clone()).expect("Failed to create KVS instance");
 
             // List of keys and corresponding values.
             let mut key_values = Vec::new();
@@ -182,29 +193,36 @@ impl Scenario for ResetSingleKey {
             // Set non-default values.
             for (key, value) in key_values.iter() {
                 // Get value parameters before set.
-                let value_is_default = kvs.is_value_default(key).unwrap();
-                let current_value = kvs.get_value_as::<f64>(key).unwrap();
+                let value_is_default = kvs
+                    .is_value_default(key)
+                    .expect("Failed to check if default value");
+                let current_value = kvs.get_value_as::<f64>(key).expect("Failed to read value");
 
                 info!(key = key, value_is_default, current_value);
 
                 // Set value.
-                kvs.set_value(key.clone(), *value).unwrap();
+                kvs.set_value(key.clone(), *value)
+                    .expect("Failed to set value");
 
                 // Get value parameters after set.
-                let value_is_default = kvs.is_value_default(key).unwrap();
-                let current_value = kvs.get_value_as::<f64>(key).unwrap();
+                let value_is_default = kvs
+                    .is_value_default(key)
+                    .expect("Failed to check if default value");
+                let current_value = kvs.get_value_as::<f64>(key).expect("Failed to read value");
 
                 info!(key, value_is_default, current_value);
             }
 
             // Reset single key.
-            kvs.reset_key(&key_values.get(reset_index).unwrap().0)
-                .unwrap();
+            kvs.reset_key(&key_values.get(reset_index).expect("Failed to read value").0)
+                .expect("Failed to reset key");
 
             // Get value parameters after reset.
             for (key, _) in key_values.iter() {
-                let value_is_default = kvs.is_value_default(key).unwrap();
-                let current_value = kvs.get_value_as::<f64>(key).unwrap();
+                let value_is_default = kvs
+                    .is_value_default(key)
+                    .expect("Failed to check if default value");
+                let current_value = kvs.get_value_as::<f64>(key).expect("Failed to read value");
 
                 info!(key, value_is_default, current_value);
             }
@@ -224,15 +242,20 @@ impl Scenario for Checksum {
 
     fn run(&self, input: Option<String>) -> Result<(), String> {
         // Create KVS instance with provided params.
-        let params = KvsParameters::from_json(input.as_ref().unwrap()).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
         let kvs_path;
         let hash_path;
         {
             // Create instance, flush, store paths to files, close instance.
-            let kvs = kvs_instance(params.clone()).unwrap();
-            kvs.flush().unwrap();
-            kvs_path = kvs.get_kvs_filename(SnapshotId(0)).unwrap();
-            hash_path = kvs.get_hash_filename(SnapshotId(0)).unwrap();
+            let kvs = kvs_instance(params.clone()).expect("Failed to create KVS instance");
+            kvs.flush().expect("Failed to flush KVS instance");
+            kvs_path = kvs
+                .get_kvs_filename(SnapshotId(0))
+                .expect("Failed to get KVS file path");
+            hash_path = kvs
+                .get_hash_filename(SnapshotId(0))
+                .expect("Failed to get hash file path");
         }
         info!(
             kvs_path = kvs_path.display().to_string(),

--- a/tests/rust_test_scenarios/src/cit/multiple_kvs.rs
+++ b/tests/rust_test_scenarios/src/cit/multiple_kvs.rs
@@ -18,29 +18,38 @@ impl Scenario for MultipleInstanceIds {
         let value2 = 222.2;
 
         // Parameters.
-        let v: Value = serde_json::from_str(input.as_ref().unwrap()).unwrap();
-        let params1 = KvsParameters::from_value(&v["kvs_parameters_1"]).unwrap();
-        let params2 = KvsParameters::from_value(&v["kvs_parameters_2"]).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let v: Value = serde_json::from_str(input_string).expect("Failed to parse input string");
+        let params1 =
+            KvsParameters::from_value(&v["kvs_parameters_1"]).expect("Failed to parse parameters");
+        let params2 =
+            KvsParameters::from_value(&v["kvs_parameters_2"]).expect("Failed to parse parameters");
         {
             // Create first KVS instance.
-            let kvs1 = kvs_instance(params1.clone()).unwrap();
+            let kvs1 = kvs_instance(params1.clone()).expect("Failed to create KVS instance");
 
             // Create seconds KVS instance.
-            let kvs2 = kvs_instance(params2.clone()).unwrap();
+            let kvs2 = kvs_instance(params2.clone()).expect("Failed to create KVS instance");
 
             // Set values to both KVS instances.
-            kvs1.set_value(&keyname, value1).unwrap();
-            kvs2.set_value(&keyname, value2).unwrap();
+            kvs1.set_value(&keyname, value1)
+                .expect("Failed to set value");
+            kvs2.set_value(&keyname, value2)
+                .expect("Failed to set value");
         }
 
         {
             // Second KVS run.
-            let kvs1 = kvs_instance(params1).unwrap();
-            let kvs2 = kvs_instance(params2).unwrap();
+            let kvs1 = kvs_instance(params1).expect("Failed to create KVS instance");
+            let kvs2 = kvs_instance(params2).expect("Failed to create KVS instance");
 
-            let value1 = kvs1.get_value_as::<f64>(&keyname).unwrap();
+            let value1 = kvs1
+                .get_value_as::<f64>(&keyname)
+                .expect("Failed to read value");
             info!(instance = "kvs1", key = keyname, value = value1);
-            let value2 = kvs2.get_value_as::<f64>(&keyname).unwrap();
+            let value2 = kvs2
+                .get_value_as::<f64>(&keyname)
+                .expect("Failed to read value");
             info!(instance = "kvs2", key = keyname, value = value2);
         }
 
@@ -61,27 +70,34 @@ impl Scenario for SameInstanceIdSameValue {
         let value = 111.1;
 
         // Parameters.
-        let params = KvsParameters::from_json(input.as_ref().unwrap()).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
         {
             // Create first KVS instance.
-            let kvs1 = kvs_instance(params.clone()).unwrap();
+            let kvs1 = kvs_instance(params.clone()).expect("Failed to create KVS instance");
 
             // Create seconds KVS instance.
-            let kvs2 = kvs_instance(params.clone()).unwrap();
+            let kvs2 = kvs_instance(params.clone()).expect("Failed to create KVS instance");
 
             // Set values to both KVS instances.
-            kvs1.set_value(&keyname, value).unwrap();
-            kvs2.set_value(&keyname, value).unwrap();
+            kvs1.set_value(&keyname, value)
+                .expect("Failed to set value");
+            kvs2.set_value(&keyname, value)
+                .expect("Failed to set value");
         }
 
         {
             // Second KVS run.
-            let kvs1 = kvs_instance(params.clone()).unwrap();
-            let kvs2 = kvs_instance(params).unwrap();
+            let kvs1 = kvs_instance(params.clone()).expect("Failed to create KVS instance");
+            let kvs2 = kvs_instance(params).expect("Failed to create KVS instance");
 
-            let value1 = kvs1.get_value_as::<f64>(&keyname).unwrap();
+            let value1 = kvs1
+                .get_value_as::<f64>(&keyname)
+                .expect("Failed to read value");
             info!(instance = "kvs1", key = keyname, value = value1);
-            let value2 = kvs2.get_value_as::<f64>(&keyname).unwrap();
+            let value2 = kvs2
+                .get_value_as::<f64>(&keyname)
+                .expect("Failed to read value");
             info!(instance = "kvs2", key = keyname, value = value2);
         }
 
@@ -103,27 +119,34 @@ impl Scenario for SameInstanceIdDifferentValue {
         let value2 = 222.2;
 
         // Parameters.
-        let params = KvsParameters::from_json(input.as_ref().unwrap()).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
         {
             // Create first KVS instance.
-            let kvs1 = kvs_instance(params.clone()).unwrap();
+            let kvs1 = kvs_instance(params.clone()).expect("Failed to create KVS instance");
 
             // Create seconds KVS instance.
-            let kvs2 = kvs_instance(params.clone()).unwrap();
+            let kvs2 = kvs_instance(params.clone()).expect("Failed to create KVS instance");
 
             // Set values to both KVS instances.
-            kvs1.set_value(&keyname, value1).unwrap();
-            kvs2.set_value(&keyname, value2).unwrap();
+            kvs1.set_value(&keyname, value1)
+                .expect("Failed to set value");
+            kvs2.set_value(&keyname, value2)
+                .expect("Failed to set value");
         }
 
         {
             // Second KVS run.
-            let kvs1 = kvs_instance(params.clone()).unwrap();
-            let kvs2 = kvs_instance(params).unwrap();
+            let kvs1 = kvs_instance(params.clone()).expect("Failed to create KVS instance");
+            let kvs2 = kvs_instance(params).expect("Failed to create KVS instance");
 
-            let value1 = kvs1.get_value_as::<f64>(&keyname).unwrap();
+            let value1 = kvs1
+                .get_value_as::<f64>(&keyname)
+                .expect("Failed to read value");
             info!(instance = "kvs1", key = keyname, value = value1);
-            let value2 = kvs2.get_value_as::<f64>(&keyname).unwrap();
+            let value2 = kvs2
+                .get_value_as::<f64>(&keyname)
+                .expect("Failed to read value");
             info!(instance = "kvs2", key = keyname, value = value2);
         }
 

--- a/tests/rust_test_scenarios/src/cit/persistency.rs
+++ b/tests/rust_test_scenarios/src/cit/persistency.rs
@@ -23,23 +23,24 @@ impl Scenario for ExplicitFlush {
         }
 
         // Check parameters.
-        let params = KvsParameters::from_json(input.as_ref().unwrap()).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
         {
             // First KVS instance object - used for setting and flushing data.
-            let kvs = kvs_instance(params.clone()).unwrap();
+            let kvs = kvs_instance(params.clone()).expect("Failed to create KVS instance");
 
             // Set values.
             for (key, value) in key_values.iter() {
-                kvs.set_value(key, *value).unwrap();
+                kvs.set_value(key, *value).expect("Failed to set value");
             }
 
             // Explicit flush.
-            kvs.flush().unwrap();
+            kvs.flush().expect("Failed to flush KVS instance");
         }
 
         {
             // Second KVS instance object - used for flush check.
-            let kvs = kvs_instance(params).unwrap();
+            let kvs = kvs_instance(params).expect("Failed to create KVS instance");
 
             // Get values.
             for (key, _) in key_values.iter() {
@@ -70,14 +71,15 @@ impl Scenario for TestFlushOnExit {
         }
 
         // Check parameters.
-        let params = KvsParameters::from_json(input.as_ref().unwrap()).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
         {
             // First KVS instance object - used for setting and flushing data.
-            let kvs = kvs_instance(params.clone()).unwrap();
+            let kvs = kvs_instance(params.clone()).expect("Failed to create KVS instance");
 
             // Set values.
             for (key, value) in key_values.iter() {
-                kvs.set_value(key, *value).unwrap();
+                kvs.set_value(key, *value).expect("Failed to set value");
             }
 
             // Flush happens on `kvs` going out of scope and `flush_on_exit` enabled.
@@ -85,7 +87,7 @@ impl Scenario for TestFlushOnExit {
 
         {
             // Second KVS instance object - used for flush check.
-            let kvs = kvs_instance(params).unwrap();
+            let kvs = kvs_instance(params).expect("Failed to create KVS instance");
 
             let snapshot_id = SnapshotId(0);
             let kvs_path_result = kvs.get_kvs_filename(snapshot_id);

--- a/tests/rust_test_scenarios/src/cit/snapshots.rs
+++ b/tests/rust_test_scenarios/src/cit/snapshots.rs
@@ -15,20 +15,21 @@ impl Scenario for SnapshotCount {
     }
 
     fn run(&self, input: Option<String>) -> Result<(), String> {
-        let input_string = input.as_ref().unwrap();
-        let v: Value = serde_json::from_str(input_string).unwrap();
-        let count = serde_json::from_value(v["count"].clone()).unwrap();
-        let params = KvsParameters::from_value(&v).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let v: Value = serde_json::from_str(input_string).expect("Failed to parse input string");
+        let count =
+            serde_json::from_value(v["count"].clone()).expect("Failed to parse \"count\" field");
+        let params = KvsParameters::from_value(&v).expect("Failed to parse parameters");
 
         // Create snapshots.
         for i in 0..count {
-            let kvs = kvs_instance(params.clone()).unwrap();
-            kvs.set_value("counter", i).unwrap();
+            let kvs = kvs_instance(params.clone()).expect("Failed to create KVS instance");
+            kvs.set_value("counter", i).expect("Failed to set value");
             info!(snapshot_count = kvs.snapshot_count());
         }
 
         {
-            let kvs = kvs_instance(params).unwrap();
+            let kvs = kvs_instance(params).expect("Failed to create KVS instance");
             info!(snapshot_count = kvs.snapshot_count());
         }
 
@@ -57,25 +58,30 @@ impl Scenario for SnapshotRestore {
     }
 
     fn run(&self, input: Option<String>) -> Result<(), String> {
-        let input_string = input.as_ref().unwrap();
-        let v: Value = serde_json::from_str(input_string).unwrap();
-        let count = serde_json::from_value(v["count"].clone()).unwrap();
-        let snapshot_id = serde_json::from_value(v["snapshot_id"].clone()).unwrap();
-        let params = KvsParameters::from_value(&v).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let v: Value = serde_json::from_str(input_string).expect("Failed to parse input string");
+        let count =
+            serde_json::from_value(v["count"].clone()).expect("Failed to parse \"count\" field");
+        let snapshot_id = serde_json::from_value(v["snapshot_id"].clone())
+            .expect("Failed to parse \"snapshot_id\" field");
+        let params = KvsParameters::from_value(&v).expect("Failed to parse parameters");
 
         // Create snapshots.
         for i in 0..count {
-            let kvs = kvs_instance(params.clone()).unwrap();
-            kvs.set_value("counter", i).unwrap();
+            let kvs = kvs_instance(params.clone()).expect("Failed to create KVS instance");
+            kvs.set_value("counter", i).expect("Failed to set value");
         }
 
         {
-            let kvs = kvs_instance(params).unwrap();
+            let kvs = kvs_instance(params).expect("Failed to create KVS instance");
 
             let result = kvs.snapshot_restore(SnapshotId(snapshot_id));
             info!(result = format!("{result:?}"));
             if let Ok(()) = result {
-                info!(value = kvs.get_value_as::<i32>("counter").unwrap());
+                let value = kvs
+                    .get_value_as::<i32>("counter")
+                    .expect("Failed to read value");
+                info!(value);
             }
         }
 
@@ -91,20 +97,22 @@ impl Scenario for SnapshotPaths {
     }
 
     fn run(&self, input: Option<String>) -> Result<(), String> {
-        let input_string = input.as_ref().unwrap();
-        let v: Value = serde_json::from_str(input_string).unwrap();
-        let count = serde_json::from_value(v["count"].clone()).unwrap();
-        let snapshot_id = serde_json::from_value(v["snapshot_id"].clone()).unwrap();
-        let params = KvsParameters::from_value(&v).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let v: Value = serde_json::from_str(input_string).expect("Failed to parse input string");
+        let count =
+            serde_json::from_value(v["count"].clone()).expect("Failed to parse \"count\" field");
+        let snapshot_id = serde_json::from_value(v["snapshot_id"].clone())
+            .expect("Failed to parse \"snapshot_id\" field");
+        let params = KvsParameters::from_value(&v).expect("Failed to parse parameters");
 
         // Create snapshots.
         for i in 0..count {
-            let kvs = kvs_instance(params.clone()).unwrap();
-            kvs.set_value("counter", i).unwrap();
+            let kvs = kvs_instance(params.clone()).expect("Failed to create KVS instance");
+            kvs.set_value("counter", i).expect("Failed to set value");
         }
 
         {
-            let kvs = kvs_instance(params).unwrap();
+            let kvs = kvs_instance(params).expect("Failed to create KVS instance");
 
             let kvs_path_result = kvs.get_kvs_filename(SnapshotId(snapshot_id));
             let hash_path_result = kvs.get_hash_filename(SnapshotId(snapshot_id));

--- a/tests/rust_test_scenarios/src/cit/supported_datatypes.rs
+++ b/tests/rust_test_scenarios/src/cit/supported_datatypes.rs
@@ -14,8 +14,9 @@ impl Scenario for SupportedDatatypesKeys {
     }
 
     fn run(&self, input: Option<String>) -> Result<(), String> {
-        let params = KvsParameters::from_json(input.as_ref().unwrap()).unwrap();
-        let kvs = kvs_instance(params).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
+        let kvs = kvs_instance(params).expect("Failed to create KVS instance");
 
         // Set key-value pairs. Unit type is used for value - only key is used later on.
         let keys_to_check = vec![
@@ -24,11 +25,11 @@ impl Scenario for SupportedDatatypesKeys {
             String::from("greek ημα"),
         ];
         for key in keys_to_check {
-            kvs.set_value(key, ()).unwrap();
+            kvs.set_value(key, ()).expect("Failed to set value");
         }
 
         // Get and print all keys.
-        let keys_in_kvs = kvs.get_all_keys().unwrap();
+        let keys_in_kvs = kvs.get_all_keys().expect("Failed to read all keys");
         for key in keys_in_kvs {
             info!(key);
         }
@@ -59,14 +60,16 @@ impl Scenario for SupportedDatatypesValues {
     }
 
     fn run(&self, input: Option<String>) -> Result<(), String> {
-        let params = KvsParameters::from_json(input.as_ref().unwrap()).unwrap();
-        let kvs = kvs_instance(params).unwrap();
+        let input_string = input.as_ref().expect("Test input is expected");
+        let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
+        let kvs = kvs_instance(params).expect("Failed to create KVS instance");
 
-        kvs.set_value(self.name(), self.value.clone()).unwrap();
+        kvs.set_value(self.name(), self.value.clone())
+            .expect("Failed to set value");
 
-        let kvs_value = kvs.get_value(self.name()).unwrap();
+        let kvs_value = kvs.get_value(self.name()).expect("Failed to read value");
         let json_value = JsonValue::from(kvs_value);
-        let json_str = json_value.stringify().unwrap();
+        let json_str = json_value.stringify().expect("Failed to stringify JSON");
 
         info!(key = self.name(), value = json_str);
 

--- a/tests/rust_test_scenarios/src/test_basic.rs
+++ b/tests/rust_test_scenarios/src/test_basic.rs
@@ -17,9 +17,10 @@ impl Scenario for BasicScenario {
 
     fn run(&self, input: Option<String>) -> Result<(), String> {
         // Print and parse parameters.
-        eprintln!("{}", input.clone().unwrap());
+        let input_string = input.as_ref().expect("Test input is expected");
+        eprintln!("{input_string}");
 
-        let params = KvsParameters::from_json(input.as_ref().unwrap()).unwrap();
+        let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
 
         // Set builder parameters.
         let mut builder = KvsBuilder::new(params.instance_id);
@@ -34,7 +35,7 @@ impl Scenario for BasicScenario {
         }
 
         // Create KVS.
-        let kvs: Kvs = builder.build().unwrap();
+        let kvs: Kvs = builder.build().expect("Failed to build KVS instance");
         if let Some(flag) = params.flush_on_exit {
             kvs.set_flush_on_exit(flag);
         }
@@ -42,8 +43,10 @@ impl Scenario for BasicScenario {
         // Simple set/get.
         let key = "example_key";
         let value = "example_value".to_string();
-        kvs.set_value(key, value).unwrap();
-        let value_read = kvs.get_value_as::<String>(key).unwrap();
+        kvs.set_value(key, value).expect("Failed to set value");
+        let value_read = kvs
+            .get_value_as::<String>(key)
+            .expect("Failed to read value");
 
         // Trace.
         info!(example_key = value_read);


### PR DESCRIPTION
Replace `unwrap` with `expect` containing description.