### PR TITLE
fix: pip_score_venv_test is only required locally

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -29,7 +29,7 @@ python.toolchain(
 )
 use_repo(python)
 
-pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip")
+pip = use_extension("@rules_python//python/extensions:pip.bzl", "pip", dev_dependency = True)
 pip.parse(
     hub_name = "pip_score_venv_test",
     python_version = PYTHON_VERSION,


### PR DESCRIPTION
pip “hub” names from rules_python must be globally unique across the whole Bazel module graph.
pip_score_venv_test conflicts with other repos, which makes integration impossible. I'll create appropriate PRs there as well.
I assume no-one outside this repo needs pip_score_venv_test.
So make it local only.