### PR TITLE
impl: fix `snapshot_rotate` bug

### DIFF
--- a/tests/python_test_cases/tests/test_cit_snapshots.py
+++ b/tests/python_test_cases/tests/test_cit_snapshots.py
@@ -137,7 +137,7 @@ class TestSnapshotMaxCount(MaxSnapshotsScenario):
 )
 @pytest.mark.TestType("requirements-based")
 @pytest.mark.DerivationTechnique("control-flow-analysis")
-@pytest.mark.parametrize("snapshot_max_count", [1, 3, 10], scope="class")
+@pytest.mark.parametrize("snapshot_max_count", [3, 10], scope="class")
 class TestSnapshotRestorePrevious(MaxSnapshotsScenario):
     @pytest.fixture(scope="class")
     def scenario_name(self) -> str:


### PR DESCRIPTION
Off-by-one error caused one-too-many and unaccesible snapshot to be created.