### PR TITLE
qnx: only build qnx after pushing on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,10 +1,6 @@
 name: QNX Rust Build Test
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 jobs:
   qnx-rust-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We are not aware of all the legal implications that come from forked PRs