### PR TITLE
bazel: use dev_dependecy for toolchains

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -175,4 +175,8 @@ use_repo(toolchains_qnx, "toolchains_qnx_sdp")
 use_repo(toolchains_qnx, "toolchains_qnx_qcc")
 
 # Registers the custom Rust toolchain wired to @qnx_rust
-register_toolchains("@toolchains_qnx_qcc//:qcc_aarch64", "@score_toolchains_rust//toolchains/aarch64-unknown-qnx8_0:toolchain_aarch64_qnx8_0")
+register_toolchains(
+    "@toolchains_qnx_qcc//:qcc_aarch64",
+    "@score_toolchains_rust//toolchains/aarch64-unknown-qnx8_0:toolchain_aarch64_qnx8_0",
+    dev_dependency = True,
+)


### PR DESCRIPTION
Use dev dependencies for toolchains