### PR TITLE
impl: backend design change

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,12 +183,6 @@ Snapshot Count:
 Snapshot Restore:
     kvs_tool -o snapshotrestore -s 1
 
-Get KVS Filename:
-    kvs_tool -o getkvsfilename -s 1
-
-Get Hash Filename:
-    kvs_tool -o gethashfilename -s 1
-
 ---------------------------------------
 
 Create Test Data:

--- a/docs/class_diagram.puml
+++ b/docs/class_diagram.puml
@@ -1,0 +1,124 @@
+@startuml Persistency class diagram
+
+package "kvs_builder" {
+    ~class KvsInner {
+        ~parameters: KvsParameters
+        ~data: KvsData
+    }
+
+    +class KvsBuilder {
+        {static} -KVS_POOL: list<KvsInner>
+        -parameters: KvsParameters
+
+        +new(instance_id: InstanceId): KvsBuilder
+        {static} +max_instances(): usize
+        +defaults(mode: KvsDefaults): KvsBuilder
+        +kvs_load(mode: KvsLoad): KvsBuilder
+        +backend_parameters(parameters: KvsMap): KvsBuilder
+        +build(): Kvs
+    }
+
+    KvsInner <-- KvsBuilder
+}
+
+package "kvs_api" {
+    +interface KvsApi {
+        +reset()
+        +reset_key(key: string)
+        +get_all_keys(): list<string>
+        +key_exists(key: string): bool
+        +get_value(key: string): KvsValue
+        +get_value_as<T>(key: string): T
+        +get_default_value(key: string): KvsValue
+        +is_value_default(key: string): bool
+        +set_value<T>(key: string, value: T)
+        +remove_key(key: string)
+        +flush()
+        +snapshot_count(): usize
+        +snapshot_max_count(): usize
+        +snapshot_restore(snapshot_id: SnapshotId)
+    }
+}
+
+package "kvs" {
+    +class Kvs {
+        -data: KvsData
+        -parameters: KvsParameters
+        -backend: KvsBackend
+
+        ~new(data: KvsData, parameters: KvsParameters, backend: KvsBackend): Kvs
+        +parameters(): KvsParameters
+
+        +reset()
+        +reset_key(key: string)
+        +get_all_keys(): list<string>
+        +key_exists(key: string): bool
+        +get_value(key: string): KvsValue
+        +get_value_as<T>(key: string): T
+        +get_default_value(key: string): KvsValue
+        +is_value_default(key: string): bool
+        +set_value<T>(key: string, value: T)
+        +remove_key(key: string)
+        +flush()
+        +snapshot_count(): usize
+        +snapshot_max_count(): usize
+        +snapshot_restore(snapshot_id: SnapshotId)
+    }
+}
+
+KvsApi <|.. Kvs
+KvsBuilder -- Kvs
+
+package "kvs_backend_registry" {
+    +class KvsBackendRegistry {
+        {static} -REGISTERED_BACKENDS: map<string, KvsBackendFactory>
+
+        {static} ~from_name(name: string) -> Result<&Box<dyn KvsBackendFactory>, ErrorCode>
+        {static} ~from_parameters(parameters: KvsMap) -> Result<&Box<dyn KvsBackendFactory>, ErrorCode>
+
+        {static} +register(backend_factory: KvsBackendFactory)
+    }
+}
+
+KvsBackendRegistry .. KvsBuilder
+
+package "kvs_backend" {
+    +interface KvsBackend {
+        +load_kvs(instance_id: InstanceId, snapshot_id: SnapshotId): KvsMap
+        +load_defaults(instance_id: InstanceId): KvsMap
+        +flush(instance_id: InstanceId, kvs_map: KvsMap)
+        +snapshot_count(instance_id: InstanceId): usize
+        +snapshot_max_count(): usize
+        +snapshot_restore(instance_id: InstanceId, snapshot_id: SnapshotId): KvsMap
+    }
+
+    +interface KvsBackendFactory {
+        +create(parameters: KvsMap): KvsBackend
+    }
+}
+
+package "json_backend" {
+    ~class JsonBackend {
+        +load_kvs(instance_id: InstanceId, snapshot_id: SnapshotId): KvsMap
+        +load_defaults(instance_id: InstanceId): KvsMap
+        +flush(instance_id: InstanceId, kvs_map: KvsMap)
+        +snapshot_count(instance_id: InstanceId): usize
+        +snapshot_max_count(): usize
+        +snapshot_restore(instance_id: InstanceId, snapshot_id: SnapshotId): KvsMap
+    }
+
+    ~class JsonBackendFactory {
+        +create(parameters: KvsMap): KvsBackend
+    }
+}
+
+KvsBackend <-- Kvs
+
+KvsBackendRegistry --> KvsBackendFactory
+KvsBackendFactory -- KvsBackend
+
+KvsBackend <|.. JsonBackend
+KvsBackendFactory <|.. JsonBackendFactory
+JsonBackendFactory -- JsonBackend
+
+@enduml

--- a/src/rust/rust_kvs/examples/backend_registration.rs
+++ b/src/rust/rust_kvs/examples/backend_registration.rs
@@ -1,0 +1,111 @@
+//! Example for custom backend registration.
+//! - Implementation of `KvsBackend` traits.
+//! - Registration of custom backend.
+//! - Creation of KVS instance utilizing custom backend.
+
+use rust_kvs::prelude::*;
+use tempfile::tempdir;
+
+/// Mock backend implementation.
+/// Only `load_kvs` is implemented.
+struct MockBackend;
+
+impl KvsBackend for MockBackend {
+    fn load_kvs(
+        &self,
+        _instance_id: InstanceId,
+        _snapshot_id: SnapshotId,
+    ) -> Result<KvsMap, ErrorCode> {
+        println!("`load_kvs` used");
+        Ok(KvsMap::new())
+    }
+
+    fn load_defaults(&self, _instance_id: InstanceId) -> Result<KvsMap, ErrorCode> {
+        unimplemented!()
+    }
+
+    fn flush(&self, _instance_id: InstanceId, _kvs_map: &KvsMap) -> Result<(), ErrorCode> {
+        unimplemented!()
+    }
+
+    fn snapshot_count(&self, _instance_id: InstanceId) -> usize {
+        unimplemented!()
+    }
+
+    fn snapshot_max_count(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn snapshot_restore(
+        &self,
+        _instance_id: InstanceId,
+        _snapshot_id: SnapshotId,
+    ) -> Result<KvsMap, ErrorCode> {
+        unimplemented!()
+    }
+}
+
+/// Mock backend factory implementation.
+struct MockBackendFactory;
+
+impl KvsBackendFactory for MockBackendFactory {
+    fn create(&self, _parameters: &KvsMap) -> Result<Box<dyn KvsBackend>, ErrorCode> {
+        Ok(Box::new(MockBackend))
+    }
+}
+
+fn main() -> Result<(), ErrorCode> {
+    // Temporary directory.
+    let dir = tempdir()?;
+    let dir_string = dir.path().to_string_lossy().to_string();
+
+    // Register `MockBackendFactory`.
+    KvsBackendRegistry::register("mock", || Box::new(MockBackendFactory))?;
+
+    // Build KVS instance with mock backend.
+    {
+        let instance_id = InstanceId(0);
+        let parameters = KvsMap::from([("name".to_string(), KvsValue::String("mock".to_string()))]);
+        let builder = KvsBuilder::new(instance_id)
+            .backend_parameters(parameters)
+            .defaults(KvsDefaults::Ignored);
+        let kvs = builder.build()?;
+
+        println!(
+            "KVS instance with mock backend - parameters: {:?}",
+            kvs.parameters()
+        );
+    }
+
+    // Build KVS instance with JSON backend - default parameters.
+    {
+        let instance_id = InstanceId(1);
+        let builder = KvsBuilder::new(instance_id).defaults(KvsDefaults::Ignored);
+        let kvs = builder.build()?;
+
+        println!(
+            "KVS instance with default JSON backend - parameters: {:?}",
+            kvs.parameters()
+        );
+    }
+
+    // Build KVS instance with JSON backend - `working_dir` set.
+    {
+        let instance_id = InstanceId(2);
+        let parameters = KvsMap::from([
+            ("name".to_string(), KvsValue::String("json".to_string())),
+            ("working_dir".to_string(), KvsValue::String(dir_string)),
+        ]);
+        let builder = KvsBuilder::new(instance_id)
+            .backend_parameters(parameters)
+            .defaults(KvsDefaults::Ignored);
+        let kvs = builder.build()?;
+
+        println!(
+            "KVS instance with JSON backend - parameters: {:?}",
+            kvs.parameters()
+        );
+    }
+
+    Ok(())
+}

--- a/src/rust/rust_kvs/examples/basic.rs
+++ b/src/rust/rust_kvs/examples/basic.rs
@@ -11,6 +11,10 @@ fn main() -> Result<(), ErrorCode> {
     // Temporary directory.
     let dir = tempdir()?;
     let dir_string = dir.path().to_string_lossy().to_string();
+    let backend_parameters = KvsMap::from([
+        ("name".to_string(), KvsValue::String("json".to_string())),
+        ("working_dir".to_string(), KvsValue::String(dir_string)),
+    ]);
 
     // Instance ID for KVS object instances.
     let instance_id = InstanceId(0);
@@ -20,7 +24,7 @@ fn main() -> Result<(), ErrorCode> {
         // `kvs_load` is explicitly set to `KvsLoad::Optional`, but this is the default value.
         // KVS files are not required.
         let builder = KvsBuilder::new(instance_id)
-            .dir(dir_string.clone())
+            .backend_parameters(backend_parameters.clone())
             .kvs_load(KvsLoad::Optional);
         let kvs = builder.build()?;
 
@@ -65,7 +69,7 @@ fn main() -> Result<(), ErrorCode> {
         // Build KVS instance for given instance ID and temporary directory.
         // `kvs_load` is set to `KvsLoad::Required` - KVS files must already exist from previous KVS instance.
         let builder = KvsBuilder::new(instance_id)
-            .dir(dir_string)
+            .backend_parameters(backend_parameters)
             .kvs_load(KvsLoad::Required);
         let kvs = builder.build()?;
 

--- a/src/rust/rust_kvs/examples/custom_types.rs
+++ b/src/rust/rust_kvs/examples/custom_types.rs
@@ -182,6 +182,10 @@ fn main() -> Result<(), ErrorCode> {
     // Temporary directory.
     let dir = tempdir()?;
     let dir_string = dir.path().to_string_lossy().to_string();
+    let backend_parameters = KvsMap::from([
+        ("name".to_string(), KvsValue::String("json".to_string())),
+        ("working_dir".to_string(), KvsValue::String(dir_string)),
+    ]);
 
     // Create initial example object.
     let object = Example {
@@ -218,7 +222,7 @@ fn main() -> Result<(), ErrorCode> {
     let kvs = KvsBuilder::new(InstanceId(0))
         .kvs_load(KvsLoad::Ignored)
         .defaults(KvsDefaults::Ignored)
-        .dir(dir_string)
+        .backend_parameters(backend_parameters)
         .build()?;
 
     // Serialize and set object.

--- a/src/rust/rust_kvs/examples/defaults.rs
+++ b/src/rust/rust_kvs/examples/defaults.rs
@@ -34,6 +34,10 @@ fn main() -> Result<(), ErrorCode> {
     // Temporary directory.
     let dir = tempdir()?;
     let dir_string = dir.path().to_string_lossy().to_string();
+    let backend_parameters = KvsMap::from([
+        ("name".to_string(), KvsValue::String("json".to_string())),
+        ("working_dir".to_string(), KvsValue::String(dir_string)),
+    ]);
 
     // Instance ID for KVS object instances.
     let instance_id = InstanceId(0);
@@ -44,7 +48,7 @@ fn main() -> Result<(), ErrorCode> {
     // Build KVS instance for given instance ID and temporary directory.
     // `defaults` is set to `KvsDefaults::Required` - defaults are required.
     let builder = KvsBuilder::new(instance_id)
-        .dir(dir_string)
+        .backend_parameters(backend_parameters)
         .defaults(KvsDefaults::Required);
     let kvs = builder.build()?;
 

--- a/src/rust/rust_kvs/examples/snapshots.rs
+++ b/src/rust/rust_kvs/examples/snapshots.rs
@@ -6,9 +6,13 @@ use rust_kvs::prelude::*;
 use tempfile::tempdir;
 
 fn main() -> Result<(), ErrorCode> {
-    // Temporary directory.
+    // Temporary directory and common backend.
     let dir = tempdir()?;
     let dir_string = dir.path().to_string_lossy().to_string();
+    let backend_parameters = KvsMap::from([
+        ("name".to_string(), KvsValue::String("json".to_string())),
+        ("working_dir".to_string(), KvsValue::String(dir_string)),
+    ]);
 
     // Instance ID for KVS object instances.
     let instance_id = InstanceId(0);
@@ -17,7 +21,7 @@ fn main() -> Result<(), ErrorCode> {
         println!("-> `snapshot_count` and `snapshot_max_count` usage");
 
         // Build KVS instance for given instance ID and temporary directory.
-        let builder = KvsBuilder::new(instance_id).dir(dir_string.clone());
+        let builder = KvsBuilder::new(instance_id).backend_parameters(backend_parameters.clone());
         let kvs = builder.build()?;
 
         let max_count = kvs.snapshot_max_count() as u32;
@@ -38,7 +42,7 @@ fn main() -> Result<(), ErrorCode> {
         println!("-> `snapshot_restore` usage");
 
         // Build KVS instance for given instance ID and temporary directory.
-        let builder = KvsBuilder::new(instance_id).dir(dir_string.clone());
+        let builder = KvsBuilder::new(instance_id).backend_parameters(backend_parameters);
         let kvs = builder.build()?;
 
         let max_count = kvs.snapshot_max_count() as u32;

--- a/src/rust/rust_kvs/src/error_code.rs
+++ b/src/rust/rust_kvs/src/error_code.rs
@@ -85,6 +85,15 @@ pub enum ErrorCode {
 
     /// Instance parameters mismatch
     InstanceParametersMismatch,
+
+    /// Requested unknown backend
+    UnknownBackend,
+
+    /// Backend already registered
+    BackendAlreadyRegistered,
+
+    /// Invalid backend parameters.
+    InvalidBackendParameters,
 }
 
 impl From<std::io::Error> for ErrorCode {

--- a/src/rust/rust_kvs/src/json_backend.rs
+++ b/src/rust/rust_kvs/src/json_backend.rs
@@ -11,7 +11,7 @@
 
 use crate::error_code::ErrorCode;
 use crate::kvs_api::{InstanceId, SnapshotId};
-use crate::kvs_backend::{KvsBackend, KvsPathResolver};
+use crate::kvs_backend::{KvsBackend, KvsBackendFactory};
 use crate::kvs_value::{KvsMap, KvsValue};
 use std::collections::HashMap;
 use std::fs;
@@ -150,8 +150,50 @@ impl From<JsonGenerateError> for ErrorCode {
     }
 }
 
+/// Builder for `JsonBackend`.
+pub(crate) struct JsonBackendBuilder {
+    working_dir: PathBuf,
+    snapshot_max_count: usize,
+}
+
+impl JsonBackendBuilder {
+    pub fn new() -> Self {
+        Self {
+            working_dir: PathBuf::new(),
+            snapshot_max_count: 3,
+        }
+    }
+
+    pub fn working_dir(mut self, working_dir: PathBuf) -> Self {
+        self.working_dir = working_dir;
+        self
+    }
+
+    pub fn snapshot_max_count(mut self, snapshot_max_count: usize) -> Self {
+        self.snapshot_max_count = snapshot_max_count;
+        self
+    }
+
+    pub fn build(self) -> JsonBackend {
+        JsonBackend {
+            working_dir: self.working_dir,
+            snapshot_max_count: self.snapshot_max_count,
+        }
+    }
+}
+
+impl Default for JsonBackendBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// KVS backend implementation based on TinyJSON.
-pub struct JsonBackend;
+#[derive(Clone, PartialEq)]
+pub(crate) struct JsonBackend {
+    working_dir: PathBuf,
+    snapshot_max_count: usize,
+}
 
 impl JsonBackend {
     fn parse(s: &str) -> Result<JsonValue, ErrorCode> {
@@ -162,15 +204,58 @@ impl JsonBackend {
         val.stringify().map_err(ErrorCode::from)
     }
 
+    /// Rotate snapshots
+    ///
+    /// # Features
+    ///   * `FEAT_REQ__KVS__snapshots`
+    ///
+    /// # Return Values
+    ///   * Ok: Rotation successful, also if no rotation was needed
+    ///   * `ErrorCode::UnmappedError`: Unmapped error
+    fn snapshot_rotate(&self, instance_id: InstanceId) -> Result<(), ErrorCode> {
+        for idx in (1..self.snapshot_max_count()).rev() {
+            let old_snapshot_id = SnapshotId(idx - 1);
+            let new_snapshot_id = SnapshotId(idx);
+
+            let hash_path_old = self.hash_file_path(instance_id, old_snapshot_id);
+            let hash_path_new = self.hash_file_path(instance_id, new_snapshot_id);
+            let snap_name_old = Self::kvs_file_name(instance_id, old_snapshot_id);
+            let snap_path_old = self.kvs_file_path(instance_id, old_snapshot_id);
+            let snap_name_new = Self::kvs_file_name(instance_id, new_snapshot_id);
+            let snap_path_new = self.kvs_file_path(instance_id, new_snapshot_id);
+
+            println!("rotating: {snap_name_old} -> {snap_name_new}");
+
+            // Check snapshot and hash files exist.
+            let snap_old_exists = snap_path_old.exists();
+            let hash_old_exists = hash_path_old.exists();
+
+            // If both exist - rename them.
+            if snap_old_exists && hash_old_exists {
+                fs::rename(hash_path_old, hash_path_new)?;
+                fs::rename(snap_path_old, snap_path_new)?;
+            }
+            // If neither exist - continue.
+            else if !snap_old_exists && !hash_old_exists {
+                continue;
+            }
+            // In other case - this is erroneous scenario.
+            // Either snapshot or hash file got removed.
+            else {
+                return Err(ErrorCode::IntegrityCorrupted);
+            }
+        }
+
+        Ok(())
+    }
+
     /// Check path have correct extension.
     fn check_extension(path: &Path, extension: &str) -> bool {
         let ext = path.extension();
         ext.is_some_and(|ep| ep.to_str().is_some_and(|es| es == extension))
     }
-}
 
-impl KvsBackend for JsonBackend {
-    fn load_kvs(kvs_path: &Path, hash_path: Option<&PathBuf>) -> Result<KvsMap, ErrorCode> {
+    pub(crate) fn load(kvs_path: &Path, hash_path: Option<&PathBuf>) -> Result<KvsMap, ErrorCode> {
         if !Self::check_extension(kvs_path, "json") {
             return Err(ErrorCode::KvsFileReadError);
         }
@@ -214,7 +299,7 @@ impl KvsBackend for JsonBackend {
         }
     }
 
-    fn save_kvs(
+    pub(crate) fn save(
         kvs_map: &KvsMap,
         kvs_path: &Path,
         hash_path: Option<&PathBuf>,
@@ -238,54 +323,150 @@ impl KvsBackend for JsonBackend {
         // Generate hash and save to hash file.
         if let Some(hash_path) = hash_path {
             let hash = adler32::RollingAdler32::from_buffer(json_str.as_bytes()).hash();
-            fs::write(hash_path, hash.to_be_bytes())?
+            fs::write(hash_path, hash.to_be_bytes())?;
         }
 
         Ok(())
     }
-}
 
-/// KVS backend path resolver for `JsonBackend`.
-impl KvsPathResolver for JsonBackend {
-    fn kvs_file_name(instance_id: InstanceId, snapshot_id: SnapshotId) -> String {
+    /// Get KVS file name.
+    pub fn kvs_file_name(instance_id: InstanceId, snapshot_id: SnapshotId) -> String {
         format!("kvs_{instance_id}_{snapshot_id}.json")
     }
 
-    fn kvs_file_path(
-        working_dir: &Path,
-        instance_id: InstanceId,
-        snapshot_id: SnapshotId,
-    ) -> PathBuf {
-        working_dir.join(Self::kvs_file_name(instance_id, snapshot_id))
+    /// Get KVS file path in working directory.
+    pub fn kvs_file_path(&self, instance_id: InstanceId, snapshot_id: SnapshotId) -> PathBuf {
+        self.working_dir
+            .join(Self::kvs_file_name(instance_id, snapshot_id))
     }
 
-    fn hash_file_name(instance_id: InstanceId, snapshot_id: SnapshotId) -> String {
+    /// Get hash file name.
+    pub fn hash_file_name(instance_id: InstanceId, snapshot_id: SnapshotId) -> String {
         format!("kvs_{instance_id}_{snapshot_id}.hash")
     }
 
-    fn hash_file_path(
-        working_dir: &Path,
-        instance_id: InstanceId,
-        snapshot_id: SnapshotId,
-    ) -> PathBuf {
-        working_dir.join(Self::hash_file_name(instance_id, snapshot_id))
+    /// Get hash file path in working directory.
+    pub fn hash_file_path(&self, instance_id: InstanceId, snapshot_id: SnapshotId) -> PathBuf {
+        self.working_dir
+            .join(Self::hash_file_name(instance_id, snapshot_id))
     }
 
-    fn defaults_file_name(instance_id: InstanceId) -> String {
+    /// Get defaults file name.
+    pub fn defaults_file_name(instance_id: InstanceId) -> String {
         format!("kvs_{instance_id}_default.json")
     }
 
-    fn defaults_file_path(working_dir: &Path, instance_id: InstanceId) -> PathBuf {
-        working_dir.join(Self::defaults_file_name(instance_id))
+    /// Get defaults file path in working directory.
+    pub fn defaults_file_path(&self, instance_id: InstanceId) -> PathBuf {
+        self.working_dir.join(Self::defaults_file_name(instance_id))
+    }
+}
+
+impl KvsBackend for JsonBackend {
+    fn load_kvs(
+        &self,
+        instance_id: InstanceId,
+        snapshot_id: SnapshotId,
+    ) -> Result<KvsMap, ErrorCode> {
+        let kvs_path = self.kvs_file_path(instance_id, snapshot_id);
+        let hash_path = self.hash_file_path(instance_id, snapshot_id);
+        Self::load(&kvs_path, Some(&hash_path))
+    }
+
+    fn load_defaults(&self, instance_id: InstanceId) -> Result<KvsMap, ErrorCode> {
+        let defaults_path = self.defaults_file_path(instance_id);
+        Self::load(&defaults_path, None)
+    }
+
+    fn flush(&self, instance_id: InstanceId, kvs_map: &KvsMap) -> Result<(), ErrorCode> {
+        self.snapshot_rotate(instance_id).map_err(|e| {
+            eprintln!("error: snapshot_rotate failed: {e:?}");
+            e
+        })?;
+        let snapshot_id = SnapshotId(0);
+        let kvs_path = self.kvs_file_path(instance_id, snapshot_id);
+        let hash_path = self.hash_file_path(instance_id, snapshot_id);
+        Self::save(kvs_map, &kvs_path, Some(&hash_path)).map_err(|e| {
+            eprintln!("error: save failed: {e:?}");
+            e
+        })?;
+        Ok(())
+    }
+
+    fn snapshot_count(&self, instance_id: InstanceId) -> usize {
+        let mut count = 0;
+
+        for idx in 0..self.snapshot_max_count {
+            let snapshot_id = SnapshotId(idx);
+            let snapshot_path = self.kvs_file_path(instance_id, snapshot_id);
+            if !snapshot_path.exists() {
+                break;
+            }
+
+            count += 1;
+        }
+
+        count
+    }
+
+    fn snapshot_max_count(&self) -> usize {
+        self.snapshot_max_count
+    }
+
+    fn snapshot_restore(
+        &self,
+        instance_id: InstanceId,
+        snapshot_id: SnapshotId,
+    ) -> Result<KvsMap, ErrorCode> {
+        // fail if the snapshot ID is the current KVS
+        if snapshot_id == SnapshotId(0) {
+            eprintln!("error: tried to restore current KVS as snapshot");
+            return Err(ErrorCode::InvalidSnapshotId);
+        }
+
+        if self.snapshot_count(instance_id) < snapshot_id.0 {
+            eprintln!("error: tried to restore a non-existing snapshot");
+            return Err(ErrorCode::InvalidSnapshotId);
+        }
+
+        self.load_kvs(instance_id, snapshot_id)
+    }
+}
+
+/// `JsonBackend` factory.
+pub(crate) struct JsonBackendFactory;
+
+impl KvsBackendFactory for JsonBackendFactory {
+    fn create(&self, parameters: &KvsMap) -> Result<Box<dyn KvsBackend>, ErrorCode> {
+        let mut builder = JsonBackendBuilder::new();
+
+        // Set working directory.
+        if let Some(working_dir) = parameters.get("working_dir") {
+            if let KvsValue::String(working_dir) = working_dir {
+                builder = builder.working_dir(PathBuf::from(working_dir));
+            } else {
+                return Err(ErrorCode::InvalidBackendParameters);
+            }
+        }
+
+        // Set snapshot max count.
+        if let Some(snapshot_max_count) = parameters.get("snapshot_max_count") {
+            if let KvsValue::U64(snapshot_max_count) = snapshot_max_count {
+                builder = builder.snapshot_max_count(*snapshot_max_count as usize);
+            } else {
+                return Err(ErrorCode::InvalidBackendParameters);
+            }
+        }
+
+        Ok(Box::new(builder.build()))
     }
 }
 
 #[cfg(test)]
 mod json_value_to_kvs_value_conversion_tests {
+    use crate::kvs_value::{KvsMap, KvsValue};
     use std::collections::HashMap;
     use tinyjson::JsonValue;
-
-    use crate::prelude::{KvsMap, KvsValue};
 
     #[test]
     fn test_i32_ok() {
@@ -720,10 +901,10 @@ mod error_code_tests {
 }
 
 #[cfg(test)]
-mod backend_tests {
+mod json_backend_tests {
     use crate::error_code::ErrorCode;
-    use crate::json_backend::JsonBackend;
-    use crate::kvs_backend::KvsBackend;
+    use crate::json_backend::{JsonBackend, JsonBackendBuilder};
+    use crate::kvs_api::{InstanceId, SnapshotId};
     use crate::kvs_value::{KvsMap, KvsValue};
     use std::path::{Path, PathBuf};
     use tempfile::tempdir;
@@ -736,121 +917,115 @@ mod backend_tests {
         ]);
         let kvs_path = working_dir.join("kvs.json");
         let hash_path = working_dir.join("kvs.hash");
-        JsonBackend::save_kvs(&kvs_map, &kvs_path, Some(&hash_path)).unwrap();
+        JsonBackend::save(&kvs_map, &kvs_path, Some(&hash_path)).unwrap();
         (kvs_path, hash_path)
     }
 
     #[test]
-    fn test_load_kvs_ok() {
+    fn test_load_ok() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
         let (kvs_path, _hash_path) = create_kvs_files(&dir_path);
 
-        let kvs_map = JsonBackend::load_kvs(&kvs_path, None).unwrap();
+        let kvs_map = JsonBackend::load(&kvs_path, None).unwrap();
         assert_eq!(kvs_map.len(), 3);
     }
 
     #[test]
-    fn test_load_kvs_not_found() {
+    fn test_load_not_found() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
         let kvs_path = dir_path.join("kvs.json");
 
-        assert!(JsonBackend::load_kvs(&kvs_path, None).is_err_and(|e| e == ErrorCode::FileNotFound));
+        assert!(JsonBackend::load(&kvs_path, None).is_err_and(|e| e == ErrorCode::FileNotFound));
     }
 
     #[test]
-    fn test_load_kvs_invalid_extension() {
+    fn test_load_invalid_extension() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
         let kvs_path = dir_path.join("kvs.invalid_ext");
 
-        assert!(
-            JsonBackend::load_kvs(&kvs_path, None).is_err_and(|e| e == ErrorCode::KvsFileReadError)
-        );
+        assert!(JsonBackend::load(&kvs_path, None).is_err_and(|e| e == ErrorCode::KvsFileReadError));
     }
 
     #[test]
-    fn test_load_kvs_malformed_json() {
+    fn test_load_malformed_json() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
         let kvs_path = dir_path.join("kvs.json");
         std::fs::write(kvs_path.clone(), "{\"malformed_json\"}").unwrap();
 
-        assert!(
-            JsonBackend::load_kvs(&kvs_path, None).is_err_and(|e| e == ErrorCode::JsonParserError)
-        );
+        assert!(JsonBackend::load(&kvs_path, None).is_err_and(|e| e == ErrorCode::JsonParserError));
     }
 
     #[test]
-    fn test_load_kvs_invalid_data() {
+    fn test_load_invalid_data() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
         let kvs_path = dir_path.join("kvs.json");
         std::fs::write(kvs_path.clone(), "[123.4, 567.8]").unwrap();
 
-        assert!(
-            JsonBackend::load_kvs(&kvs_path, None).is_err_and(|e| e == ErrorCode::JsonParserError)
-        );
+        assert!(JsonBackend::load(&kvs_path, None).is_err_and(|e| e == ErrorCode::JsonParserError));
     }
 
     #[test]
-    fn test_load_kvs_hash_path_some_ok() {
+    fn test_load_hash_path_some_ok() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
         let (kvs_path, hash_path) = create_kvs_files(&dir_path);
 
-        let kvs_map = JsonBackend::load_kvs(&kvs_path, Some(&hash_path)).unwrap();
+        let kvs_map = JsonBackend::load(&kvs_path, Some(&hash_path)).unwrap();
         assert_eq!(kvs_map.len(), 3);
     }
 
     #[test]
-    fn test_load_kvs_hash_path_some_invalid_extension() {
+    fn test_load_hash_path_some_invalid_extension() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
         let (kvs_path, hash_path) = create_kvs_files(&dir_path);
         let new_hash_path = hash_path.with_extension("invalid_ext");
         std::fs::rename(hash_path, new_hash_path.clone()).unwrap();
 
-        assert!(JsonBackend::load_kvs(&kvs_path, Some(&new_hash_path))
+        assert!(JsonBackend::load(&kvs_path, Some(&new_hash_path))
             .is_err_and(|e| e == ErrorCode::KvsHashFileReadError));
     }
 
     #[test]
-    fn test_load_kvs_hash_path_some_not_found() {
+    fn test_load_hash_path_some_not_found() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
         let (kvs_path, hash_path) = create_kvs_files(&dir_path);
         std::fs::remove_file(hash_path.clone()).unwrap();
 
-        assert!(JsonBackend::load_kvs(&kvs_path, Some(&hash_path))
+        assert!(JsonBackend::load(&kvs_path, Some(&hash_path))
             .is_err_and(|e| e == ErrorCode::KvsHashFileReadError));
     }
 
     #[test]
-    fn test_load_kvs_invalid_hash_content() {
+    fn test_load_invalid_hash_content() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
         let (kvs_path, hash_path) = create_kvs_files(&dir_path);
         std::fs::write(hash_path.clone(), vec![0x12, 0x34, 0x56, 0x78]).unwrap();
 
-        assert!(JsonBackend::load_kvs(&kvs_path, Some(&hash_path))
+        assert!(JsonBackend::load(&kvs_path, Some(&hash_path))
             .is_err_and(|e| e == ErrorCode::ValidationFailed));
     }
 
     #[test]
-    fn test_load_kvs_invalid_hash_len() {
+    fn test_load_invalid_hash_len() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
         let (kvs_path, hash_path) = create_kvs_files(&dir_path);
         std::fs::write(hash_path.clone(), vec![0x12, 0x34, 0x56]).unwrap();
 
-        assert!(JsonBackend::load_kvs(&kvs_path, Some(&hash_path))
+        assert!(JsonBackend::load(&kvs_path, Some(&hash_path))
             .is_err_and(|e| e == ErrorCode::ValidationFailed));
     }
 
     #[test]
-    fn test_save_kvs_ok() {
+    fn test_save_ok() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
 
@@ -860,24 +1035,24 @@ mod backend_tests {
             ("k3".to_string(), KvsValue::from(123.4)),
         ]);
         let kvs_path = dir_path.join("kvs.json");
-        JsonBackend::save_kvs(&kvs_map, &kvs_path, None).unwrap();
+        JsonBackend::save(&kvs_map, &kvs_path, None).unwrap();
 
         assert!(kvs_path.exists());
     }
 
     #[test]
-    fn test_save_kvs_invalid_extension() {
+    fn test_save_invalid_extension() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
 
         let kvs_map = KvsMap::new();
         let kvs_path = dir_path.join("kvs.invalid_ext");
-        assert!(JsonBackend::save_kvs(&kvs_map, &kvs_path, None)
+        assert!(JsonBackend::save(&kvs_map, &kvs_path, None)
             .is_err_and(|e| e == ErrorCode::KvsFileReadError));
     }
 
     #[test]
-    fn test_save_kvs_hash_path_some_ok() {
+    fn test_save_hash_path_some_ok() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
 
@@ -888,42 +1063,34 @@ mod backend_tests {
         ]);
         let kvs_path = dir_path.join("kvs.json");
         let hash_path = dir_path.join("kvs.hash");
-        JsonBackend::save_kvs(&kvs_map, &kvs_path, Some(&hash_path)).unwrap();
+        JsonBackend::save(&kvs_map, &kvs_path, Some(&hash_path)).unwrap();
 
         assert!(kvs_path.exists());
         assert!(hash_path.exists());
     }
 
     #[test]
-    fn test_save_kvs_hash_path_some_invalid_extension() {
+    fn test_save_hash_path_some_invalid_extension() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
 
         let kvs_map = KvsMap::new();
         let kvs_path = dir_path.join("kvs.json");
         let hash_path = dir_path.join("kvs.invalid_ext");
-        assert!(JsonBackend::save_kvs(&kvs_map, &kvs_path, Some(&hash_path))
+        assert!(JsonBackend::save(&kvs_map, &kvs_path, Some(&hash_path))
             .is_err_and(|e| e == ErrorCode::KvsHashFileReadError));
     }
 
     #[test]
-    fn test_save_kvs_impossible_str() {
+    fn test_save_impossible_str() {
         let dir = tempdir().unwrap();
         let dir_path = dir.path().to_path_buf();
 
         let kvs_map = KvsMap::from([("inf".to_string(), KvsValue::from(f64::INFINITY))]);
         let kvs_path = dir_path.join("kvs.json");
-        assert!(JsonBackend::save_kvs(&kvs_map, &kvs_path, None)
+        assert!(JsonBackend::save(&kvs_map, &kvs_path, None)
             .is_err_and(|e| e == ErrorCode::JsonGeneratorError));
     }
-}
-
-#[cfg(test)]
-mod path_resolver_tests {
-    use crate::json_backend::JsonBackend;
-    use crate::kvs_api::{InstanceId, SnapshotId};
-    use crate::kvs_backend::KvsPathResolver;
-    use tempfile::tempdir;
 
     #[test]
     fn test_kvs_file_name() {
@@ -937,12 +1104,15 @@ mod path_resolver_tests {
     #[test]
     fn test_kvs_file_path() {
         let dir = tempdir().unwrap();
-        let dir_path = dir.path();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new()
+            .working_dir(dir_path.clone())
+            .build();
 
         let instance_id = InstanceId(123);
         let snapshot_id = SnapshotId(2);
         let exp_name = dir_path.join(format!("kvs_{instance_id}_{snapshot_id}.json"));
-        let act_name = JsonBackend::kvs_file_path(dir_path, instance_id, snapshot_id);
+        let act_name = backend.kvs_file_path(instance_id, snapshot_id);
         assert_eq!(exp_name, act_name);
     }
     #[test]
@@ -957,12 +1127,15 @@ mod path_resolver_tests {
     #[test]
     fn test_hash_file_path() {
         let dir = tempdir().unwrap();
-        let dir_path = dir.path();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new()
+            .working_dir(dir_path.clone())
+            .build();
 
         let instance_id = InstanceId(123);
         let snapshot_id = SnapshotId(2);
         let exp_name = dir_path.join(format!("kvs_{instance_id}_{snapshot_id}.hash"));
-        let act_name = JsonBackend::hash_file_path(dir_path, instance_id, snapshot_id);
+        let act_name = backend.hash_file_path(instance_id, snapshot_id);
         assert_eq!(exp_name, act_name);
     }
 
@@ -977,11 +1150,293 @@ mod path_resolver_tests {
     #[test]
     fn test_defaults_file_path() {
         let dir = tempdir().unwrap();
-        let dir_path = dir.path();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new()
+            .working_dir(dir_path.clone())
+            .build();
 
         let instance_id = InstanceId(123);
         let exp_name = dir_path.join(format!("kvs_{instance_id}_default.json"));
-        let act_name = JsonBackend::defaults_file_path(dir_path, instance_id);
+        let act_name = backend.defaults_file_path(instance_id);
         assert_eq!(exp_name, act_name);
+    }
+}
+
+#[cfg(test)]
+mod kvs_backend_tests {
+    use crate::error_code::ErrorCode;
+    use crate::json_backend::{JsonBackend, JsonBackendBuilder};
+    use crate::kvs_api::{InstanceId, SnapshotId};
+    use crate::kvs_backend::KvsBackend;
+    use crate::kvs_value::{KvsMap, KvsValue};
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn create_kvs_files(backend: &JsonBackend, instance_id: InstanceId, snapshot_id: SnapshotId) {
+        let kvs_map = KvsMap::from([
+            ("k1".to_string(), KvsValue::from("v1")),
+            ("k2".to_string(), KvsValue::from(true)),
+            ("k3".to_string(), KvsValue::from(123.4)),
+        ]);
+        let kvs_path = backend.kvs_file_path(instance_id, snapshot_id);
+        let hash_path = backend.hash_file_path(instance_id, snapshot_id);
+        JsonBackend::save(&kvs_map, &kvs_path, Some(&hash_path)).unwrap();
+    }
+
+    fn create_defaults_file(backend: &JsonBackend, instance_id: InstanceId) {
+        let kvs_map = KvsMap::from([
+            ("k4".to_string(), KvsValue::from("v4")),
+            ("k5".to_string(), KvsValue::from(432.1)),
+        ]);
+        let defaults_path = backend.defaults_file_path(instance_id);
+        JsonBackend::save(&kvs_map, &defaults_path, None).unwrap();
+    }
+
+    #[test]
+    fn test_load_kvs_ok() {
+        // Main `load` tests are performed by `test_load_*` tests.
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new().working_dir(dir_path).build();
+        let instance_id = InstanceId(1);
+        let snapshot_id = SnapshotId(1);
+        create_kvs_files(&backend, instance_id, snapshot_id);
+
+        let kvs_map = backend.load_kvs(instance_id, snapshot_id).unwrap();
+        assert_eq!(kvs_map.len(), 3);
+    }
+
+    #[test]
+    fn test_load_defaults_ok() {
+        // Main `load` tests are performed by `test_load_*` tests.
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new().working_dir(dir_path).build();
+        let instance_id = InstanceId(1);
+        create_defaults_file(&backend, instance_id);
+
+        let kvs_map = backend.load_defaults(instance_id).unwrap();
+        assert_eq!(kvs_map.len(), 2);
+    }
+
+    #[test]
+    fn test_flush_ok() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new().working_dir(dir_path).build();
+        let instance_id = InstanceId(1);
+
+        // Flush.
+        let kvs_map = KvsMap::from([("key".to_string(), KvsValue::from("value"))]);
+        backend.flush(instance_id, &kvs_map).unwrap();
+
+        // Check files exist.
+        let snapshot_id = SnapshotId(0);
+        let kvs_path = backend.kvs_file_path(instance_id, snapshot_id);
+        let hash_path = backend.hash_file_path(instance_id, snapshot_id);
+        assert!(kvs_path.exists());
+        assert!(hash_path.exists());
+    }
+
+    #[test]
+    fn test_flush_kvs_removed() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new().working_dir(dir_path).build();
+        let instance_id = InstanceId(1);
+
+        // Flush.
+        let kvs_map = KvsMap::from([("key".to_string(), KvsValue::from("value"))]);
+        backend.flush(instance_id, &kvs_map).unwrap();
+
+        // Remove KVS file.
+        let snapshot_id = SnapshotId(0);
+        let kvs_path = backend.kvs_file_path(instance_id, snapshot_id);
+        fs::remove_file(kvs_path).unwrap();
+
+        // Flush again.
+        let result = backend.flush(instance_id, &kvs_map);
+        assert!(result.is_err_and(|e| e == ErrorCode::IntegrityCorrupted));
+    }
+
+    #[test]
+    fn test_flush_hash_removed() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new().working_dir(dir_path).build();
+        let instance_id = InstanceId(1);
+
+        // Flush.
+        let kvs_map = KvsMap::from([("key".to_string(), KvsValue::from("value"))]);
+        backend.flush(instance_id, &kvs_map).unwrap();
+
+        // Remove KVS file.
+        let snapshot_id = SnapshotId(0);
+        let hash_path = backend.hash_file_path(instance_id, snapshot_id);
+        fs::remove_file(hash_path).unwrap();
+
+        // Flush again.
+        let result = backend.flush(instance_id, &kvs_map);
+        assert!(result.is_err_and(|e| e == ErrorCode::IntegrityCorrupted));
+    }
+
+    #[test]
+    fn test_snapshot_count_zero() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new().working_dir(dir_path).build();
+        let instance_id = InstanceId(2);
+
+        assert_eq!(backend.snapshot_count(instance_id), 0);
+    }
+
+    #[test]
+    fn test_snapshot_count_to_one() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new().working_dir(dir_path).build();
+        let instance_id = InstanceId(2);
+
+        backend.flush(instance_id, &KvsMap::new()).unwrap();
+        assert_eq!(backend.snapshot_count(instance_id), 1);
+    }
+
+    #[test]
+    fn test_snapshot_count_to_max() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new().working_dir(dir_path).build();
+        let instance_id = InstanceId(2);
+
+        for i in 1..=backend.snapshot_max_count() {
+            backend.flush(instance_id, &KvsMap::new()).unwrap();
+            assert_eq!(backend.snapshot_count(instance_id), i);
+        }
+
+        backend.flush(instance_id, &KvsMap::new()).unwrap();
+        backend.flush(instance_id, &KvsMap::new()).unwrap();
+        assert_eq!(
+            backend.snapshot_count(instance_id),
+            backend.snapshot_max_count()
+        );
+    }
+
+    #[test]
+    fn test_snapshot_max_count() {
+        let max_count = 1234;
+        let backend = JsonBackendBuilder::new()
+            .snapshot_max_count(max_count)
+            .build();
+        assert_eq!(backend.snapshot_max_count(), max_count);
+    }
+
+    #[test]
+    fn test_snapshot_restore_ok() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new().working_dir(dir_path).build();
+        let instance_id = InstanceId(2);
+
+        // Prepare snapshots.
+        for i in 1..=backend.snapshot_max_count() {
+            let kvs_map = KvsMap::from([("counter".to_string(), KvsValue::I32(i as i32))]);
+            backend.flush(instance_id, &kvs_map).unwrap();
+        }
+
+        // Check restore.
+        let kvs_map = backend
+            .snapshot_restore(instance_id, SnapshotId(1))
+            .unwrap();
+        assert_eq!(*kvs_map.get("counter").unwrap(), KvsValue::I32(2));
+    }
+
+    #[test]
+    fn test_snapshot_restore_invalid_id() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new().working_dir(dir_path).build();
+        let instance_id = InstanceId(2);
+
+        // Prepare snapshots.
+        for i in 1..=backend.snapshot_max_count() {
+            let kvs_map = KvsMap::from([("counter".to_string(), KvsValue::I32(i as i32))]);
+            backend.flush(instance_id, &kvs_map).unwrap();
+        }
+
+        let result = backend.snapshot_restore(instance_id, SnapshotId(123));
+        assert!(result.is_err_and(|e| e == ErrorCode::InvalidSnapshotId));
+    }
+
+    #[test]
+    fn test_snapshot_restore_current_id() {
+        let dir = tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let backend = JsonBackendBuilder::new().working_dir(dir_path).build();
+        let instance_id = InstanceId(2);
+
+        // Prepare snapshots.
+        for i in 1..=backend.snapshot_max_count() {
+            let kvs_map = KvsMap::from([("counter".to_string(), KvsValue::I32(i as i32))]);
+            backend.flush(instance_id, &kvs_map).unwrap();
+        }
+
+        let result = backend.snapshot_restore(instance_id, SnapshotId(0));
+        assert!(result.is_err_and(|e| e == ErrorCode::InvalidSnapshotId));
+    }
+}
+
+#[cfg(test)]
+mod kvs_backend_factory_tests {
+    use crate::error_code::ErrorCode;
+    use crate::json_backend::JsonBackendFactory;
+    use crate::kvs_backend::KvsBackendFactory;
+    use crate::kvs_value::{KvsMap, KvsValue};
+
+    #[test]
+    fn test_create_default_ok() {
+        let factory = JsonBackendFactory;
+        let params = KvsMap::new();
+        let backend = factory.create(&params).unwrap();
+        // `working_dir` is not exposed in the API.
+        assert_eq!(backend.snapshot_max_count(), 3);
+    }
+
+    #[test]
+    fn test_create_params_ok() {
+        let factory = JsonBackendFactory;
+        let params = KvsMap::from([
+            (
+                "working_dir".to_string(),
+                KvsValue::String("/some/path/".to_string()),
+            ),
+            ("snapshot_max_count".to_string(), KvsValue::U64(1234)),
+        ]);
+        let backend = factory.create(&params).unwrap();
+        // `working_dir` is not exposed in the API.
+        assert_eq!(backend.snapshot_max_count(), 1234);
+    }
+
+    #[test]
+    fn test_create_working_dir_invalid_type() {
+        let factory = JsonBackendFactory;
+        let params = KvsMap::from([("working_dir".to_string(), KvsValue::Boolean(true))]);
+        let result = factory.create(&params);
+        assert!(result.is_err_and(|e| e == ErrorCode::InvalidBackendParameters));
+    }
+
+    #[test]
+    fn test_create_snapshot_max_count_invalid_type() {
+        let factory = JsonBackendFactory;
+        let params = KvsMap::from([("snapshot_max_count".to_string(), KvsValue::I32(-123))]);
+        let result = factory.create(&params);
+        assert!(result.is_err_and(|e| e == ErrorCode::InvalidBackendParameters));
+    }
+
+    #[test]
+    fn test_create_unknown_param_ok() {
+        let factory = JsonBackendFactory;
+        let params = KvsMap::from([("unknown_param".to_string(), KvsValue::I32(12345))]);
+        let result = factory.create(&params);
+        assert!(result.is_ok());
     }
 }

--- a/src/rust/rust_kvs/src/kvs_api.rs
+++ b/src/rust/rust_kvs/src/kvs_api.rs
@@ -12,10 +12,9 @@
 use crate::error_code::ErrorCode;
 use crate::kvs_value::KvsValue;
 use core::fmt;
-use std::path::PathBuf;
 
 /// Instance ID
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct InstanceId(pub usize);
 
 impl fmt::Display for InstanceId {
@@ -31,7 +30,7 @@ impl From<InstanceId> for usize {
 }
 
 /// Snapshot ID
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct SnapshotId(pub usize);
 
 impl fmt::Display for SnapshotId {
@@ -47,7 +46,7 @@ impl From<SnapshotId> for usize {
 }
 
 /// Defaults handling mode.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum KvsDefaults {
     /// Defaults are not loaded.
     Ignored,
@@ -60,7 +59,7 @@ pub enum KvsDefaults {
 }
 
 /// KVS load mode.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum KvsLoad {
     /// KVS is not loaded.
     Ignored,
@@ -94,8 +93,6 @@ pub trait KvsApi {
     fn snapshot_count(&self) -> usize;
     fn snapshot_max_count(&self) -> usize;
     fn snapshot_restore(&self, snapshot_id: SnapshotId) -> Result<(), ErrorCode>;
-    fn get_kvs_filename(&self, snapshot_id: SnapshotId) -> Result<PathBuf, ErrorCode>;
-    fn get_hash_filename(&self, snapshot_id: SnapshotId) -> Result<PathBuf, ErrorCode>;
 }
 
 #[cfg(test)]

--- a/src/rust/rust_kvs/src/kvs_backend_registry.rs
+++ b/src/rust/rust_kvs/src/kvs_backend_registry.rs
@@ -1,0 +1,235 @@
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// <https://www.apache.org/licenses/LICENSE-2.0>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::error_code::ErrorCode;
+use crate::kvs_backend::KvsBackendFactory;
+use crate::kvs_value::{KvsMap, KvsValue};
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex, MutexGuard, PoisonError};
+
+/// Function providing backend factory.
+type KvsBackendFactoryFn = fn() -> Box<dyn KvsBackendFactory>;
+
+/// Map containing names as strings and factory-creating functions as values.
+type BackendMap = HashMap<String, KvsBackendFactoryFn>;
+
+/// Provide map containing default backends.
+fn default_backends() -> BackendMap {
+    let mut backends: BackendMap = HashMap::new();
+    // Register JSON backend.
+    {
+        use crate::json_backend::JsonBackendFactory;
+        backends.insert("json".to_string(), || Box::new(JsonBackendFactory));
+    }
+
+    backends
+}
+
+/// Pool containing registered backend factories.
+static REGISTERED_BACKENDS: LazyLock<Mutex<BackendMap>> =
+    LazyLock::new(|| Mutex::new(default_backends()));
+
+impl From<PoisonError<MutexGuard<'_, BackendMap>>> for ErrorCode {
+    fn from(_cause: PoisonError<MutexGuard<'_, BackendMap>>) -> Self {
+        ErrorCode::MutexLockFailed
+    }
+}
+
+/// KVS backend registry.
+pub struct KvsBackendRegistry;
+
+impl KvsBackendRegistry {
+    /// Get registered backend using name.
+    pub(crate) fn from_name(name: &str) -> Result<Box<dyn KvsBackendFactory>, ErrorCode> {
+        let registered_backends = REGISTERED_BACKENDS.lock()?;
+
+        match registered_backends.get(name) {
+            Some(backend_factory_fn) => Ok(backend_factory_fn()),
+            None => Err(ErrorCode::UnknownBackend),
+        }
+    }
+
+    /// Get registered backend using 'name' field from parameters.
+    pub(crate) fn from_parameters(
+        parameters: &KvsMap,
+    ) -> Result<Box<dyn KvsBackendFactory>, ErrorCode> {
+        let name = match parameters.get("name") {
+            Some(value) => match value {
+                KvsValue::String(name) => Ok(name),
+                _ => Err(ErrorCode::InvalidBackendParameters),
+            },
+            None => Err(ErrorCode::KeyNotFound),
+        }?;
+
+        Self::from_name(name)
+    }
+
+    /// Register new backend factory.
+    pub fn register(name: &str, backend_factory_fn: KvsBackendFactoryFn) -> Result<(), ErrorCode> {
+        let mut registered_backends = REGISTERED_BACKENDS.lock()?;
+
+        // Check backend factory already registered.
+        if registered_backends.contains_key(name) {
+            return Err(ErrorCode::BackendAlreadyRegistered);
+        }
+
+        // Insert backend factory.
+        registered_backends.insert(name.to_string(), backend_factory_fn);
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod registry_tests {
+    use crate::error_code::ErrorCode;
+    use crate::kvs_api::{InstanceId, SnapshotId};
+    use crate::kvs_backend::{KvsBackend, KvsBackendFactory};
+    use crate::kvs_backend_registry::{default_backends, KvsBackendRegistry, REGISTERED_BACKENDS};
+    use crate::kvs_value::{KvsMap, KvsValue};
+    use std::ops::DerefMut;
+    use std::sync::{LazyLock, Mutex, MutexGuard};
+
+    /// Serial test execution mutex.
+    static SERIAL_TEST: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+    /// Execute test serially with registry initialized to default.
+    fn lock_and_reset<'a>() -> MutexGuard<'a, ()> {
+        // Tests in this group must be executed serially.
+        let serial_lock: MutexGuard<'a, ()> = SERIAL_TEST.lock().unwrap();
+
+        // Reset `REGISTERED_BACKENDS` state to default.
+        // This is to mitigate `BackendAlreadyRegistered` errors between tests.
+        let mut registry = REGISTERED_BACKENDS.lock().unwrap();
+        *registry.deref_mut() = default_backends();
+
+        serial_lock
+    }
+
+    /// Mock backend.
+    struct MockBackend {
+        parameters: KvsMap,
+    }
+
+    impl KvsBackend for MockBackend {
+        /// `load_kvs` is reused to access parameters used by factory.
+        fn load_kvs(
+            &self,
+            _instance_id: InstanceId,
+            _snapshot_id: SnapshotId,
+        ) -> Result<KvsMap, ErrorCode> {
+            Ok(self.parameters.clone())
+        }
+
+        fn load_defaults(&self, _instance_id: InstanceId) -> Result<KvsMap, ErrorCode> {
+            unimplemented!()
+        }
+
+        fn flush(&self, _instance_id: InstanceId, _kvs_map: &KvsMap) -> Result<(), ErrorCode> {
+            unimplemented!()
+        }
+
+        fn snapshot_count(&self, _instance_id: InstanceId) -> usize {
+            unimplemented!()
+        }
+
+        fn snapshot_max_count(&self) -> usize {
+            unimplemented!()
+        }
+
+        fn snapshot_restore(
+            &self,
+            _instance_id: InstanceId,
+            _snapshot_id: SnapshotId,
+        ) -> Result<KvsMap, ErrorCode> {
+            unimplemented!()
+        }
+    }
+
+    /// Mock backend factory.
+    struct MockBackendFactory;
+
+    impl KvsBackendFactory for MockBackendFactory {
+        fn create(&self, parameters: &KvsMap) -> Result<Box<dyn KvsBackend>, ErrorCode> {
+            Ok(Box::new(MockBackend {
+                parameters: parameters.clone(),
+            }))
+        }
+    }
+
+    #[test]
+    fn test_from_name_ok() {
+        let _lock = lock_and_reset();
+
+        let result = KvsBackendRegistry::from_name("json");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_from_name_unknown() {
+        let _lock = lock_and_reset();
+
+        let result = KvsBackendRegistry::from_name("unknown");
+        assert!(result.is_err_and(|e| e == ErrorCode::UnknownBackend));
+    }
+
+    #[test]
+    fn test_from_parameters_ok() {
+        let _lock = lock_and_reset();
+
+        let params = KvsMap::from([("name".to_string(), KvsValue::String("json".to_string()))]);
+        let result = KvsBackendRegistry::from_parameters(&params);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_from_parameters_unknown() {
+        let _lock = lock_and_reset();
+
+        let params = KvsMap::from([("name".to_string(), KvsValue::String("unknown".to_string()))]);
+        let result = KvsBackendRegistry::from_parameters(&params);
+        assert!(result.is_err_and(|e| e == ErrorCode::UnknownBackend));
+    }
+
+    #[test]
+    fn test_from_parameters_invalid_type() {
+        let _lock = lock_and_reset();
+
+        let params = KvsMap::from([("name".to_string(), KvsValue::I64(123))]);
+        let result = KvsBackendRegistry::from_parameters(&params);
+        assert!(result.is_err_and(|e| e == ErrorCode::InvalidBackendParameters));
+    }
+
+    #[test]
+    fn test_from_parameters_missing_name() {
+        let _lock = lock_and_reset();
+
+        let params = KvsMap::new();
+        let result = KvsBackendRegistry::from_parameters(&params);
+        assert!(result.is_err_and(|e| e == ErrorCode::KeyNotFound));
+    }
+
+    #[test]
+    fn test_register_ok() {
+        let _lock = lock_and_reset();
+
+        let result = KvsBackendRegistry::register("mock", || Box::new(MockBackendFactory));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_register_already_registered() {
+        let _lock = lock_and_reset();
+
+        KvsBackendRegistry::register("mock", || Box::new(MockBackendFactory)).unwrap();
+        let result = KvsBackendRegistry::register("mock", || Box::new(MockBackendFactory));
+        assert!(result.is_err_and(|e| e == ErrorCode::BackendAlreadyRegistered))
+    }
+}

--- a/src/rust/rust_kvs/src/kvs_mock.rs
+++ b/src/rust/rust_kvs/src/kvs_mock.rs
@@ -139,18 +139,6 @@ impl KvsApi for MockKvs {
         }
         Ok(())
     }
-    fn get_kvs_filename(&self, _id: SnapshotId) -> Result<std::path::PathBuf, ErrorCode> {
-        if self.fail {
-            return Err(ErrorCode::UnmappedError);
-        }
-        Err(ErrorCode::FileNotFound)
-    }
-    fn get_hash_filename(&self, _id: SnapshotId) -> Result<std::path::PathBuf, ErrorCode> {
-        if self.fail {
-            return Err(ErrorCode::UnmappedError);
-        }
-        Err(ErrorCode::FileNotFound)
-    }
 }
 
 #[cfg(test)]
@@ -190,8 +178,6 @@ mod tests {
         assert!(kvs_fail.reset_key("a").is_err());
         assert!(kvs_fail.get_default_value("a").is_err());
         assert!(kvs_fail.is_value_default("a").is_err());
-        assert!(kvs_fail.get_kvs_filename(SnapshotId(0)).is_err());
-        assert!(kvs_fail.get_hash_filename(SnapshotId(0)).is_err());
         assert!(kvs_fail.snapshot_restore(SnapshotId(0)).is_err());
     }
 }

--- a/src/rust/rust_kvs/src/lib.rs
+++ b/src/rust/rust_kvs/src/lib.rs
@@ -135,23 +135,21 @@ pub mod error_code;
 mod json_backend;
 pub mod kvs;
 pub mod kvs_api;
-mod kvs_backend;
+pub mod kvs_backend;
+pub mod kvs_backend_registry;
 pub mod kvs_builder;
 pub mod kvs_mock;
 pub mod kvs_serialize;
 pub mod kvs_value;
 
-use json_backend::JsonBackend;
-pub type KvsBuilder = kvs_builder::GenericKvsBuilder<JsonBackend>;
-pub type Kvs = kvs::GenericKvs<JsonBackend>;
-
 /// Prelude module for convenient imports
 pub mod prelude {
     pub use crate::error_code::ErrorCode;
-    pub use crate::kvs::GenericKvs;
+    pub use crate::kvs::Kvs;
     pub use crate::kvs_api::{InstanceId, KvsApi, KvsDefaults, KvsLoad, SnapshotId};
-    pub use crate::kvs_builder::GenericKvsBuilder;
+    pub use crate::kvs_backend::{KvsBackend, KvsBackendFactory};
+    pub use crate::kvs_backend_registry::KvsBackendRegistry;
+    pub use crate::kvs_builder::KvsBuilder;
     pub use crate::kvs_serialize::{KvsDeserialize, KvsSerialize};
     pub use crate::kvs_value::{KvsMap, KvsValue};
-    pub use crate::{Kvs, KvsBuilder};
 }

--- a/tests/python_test_cases/tests/test_cit_snapshots.py
+++ b/tests/python_test_cases/tests/test_cit_snapshots.py
@@ -294,8 +294,10 @@ class TestSnapshotPathsExist(CommonScenario):
 
         paths_log = logs_info_level.find_log("kvs_path")
         assert paths_log is not None
-        assert paths_log.kvs_path == f'Ok("{temp_dir}/kvs_1_1.json")'
-        assert paths_log.hash_path == f'Ok("{temp_dir}/kvs_1_1.hash")'
+        assert paths_log.kvs_path == f'"{temp_dir}/kvs_1_1.json"'
+        assert paths_log.kvs_path_exists
+        assert paths_log.hash_path == f'"{temp_dir}/kvs_1_1.hash"'
+        assert paths_log.hash_path_exists
 
 
 @pytest.mark.PartiallyVerifies(["comp_req__persistency__snapshot_creation"])
@@ -320,6 +322,7 @@ class TestSnapshotPathsNonexistent(CommonScenario):
 
     def test_error(
         self,
+        temp_dir: Path,
         results: ScenarioResult,
         logs_info_level: LogContainer,
     ):
@@ -327,5 +330,7 @@ class TestSnapshotPathsNonexistent(CommonScenario):
 
         paths_log = logs_info_level.find_log("kvs_path")
         assert paths_log is not None
-        assert paths_log.kvs_path == "Err(FileNotFound)"
-        assert paths_log.hash_path == "Err(FileNotFound)"
+        assert paths_log.kvs_path == f'"{temp_dir}/kvs_1_2.json"'
+        assert not paths_log.kvs_path_exists
+        assert paths_log.hash_path == f'"{temp_dir}/kvs_1_2.hash"'
+        assert not paths_log.hash_path_exists

--- a/tests/rust_test_scenarios/src/cit/multiple_kvs.rs
+++ b/tests/rust_test_scenarios/src/cit/multiple_kvs.rs
@@ -1,4 +1,5 @@
-use crate::helpers::{kvs_instance::kvs_instance, kvs_parameters::KvsParameters};
+use crate::helpers::kvs_instance::kvs_instance;
+use crate::helpers::kvs_parameters::KvsParameters;
 use rust_kvs::prelude::KvsApi;
 use serde_json::Value;
 use test_scenarios_rust::scenario::{Scenario, ScenarioGroup, ScenarioGroupImpl};

--- a/tests/rust_test_scenarios/src/cit/snapshots.rs
+++ b/tests/rust_test_scenarios/src/cit/snapshots.rs
@@ -1,4 +1,6 @@
-use crate::helpers::{kvs_instance::kvs_instance, kvs_parameters::KvsParameters};
+use crate::helpers::kvs_instance::kvs_instance;
+use crate::helpers::kvs_parameters::KvsParameters;
+use crate::helpers::{kvs_hash_paths, to_str};
 use rust_kvs::prelude::{KvsApi, SnapshotId};
 use serde_json::Value;
 use test_scenarios_rust::scenario::{Scenario, ScenarioGroup, ScenarioGroupImpl};
@@ -112,6 +114,7 @@ impl Scenario for SnapshotPaths {
         let snapshot_id = serde_json::from_value(v["snapshot_id"].clone())
             .expect("Failed to parse \"snapshot_id\" field");
         let params = KvsParameters::from_value(&v).expect("Failed to parse parameters");
+        let working_dir = params.dir.clone().expect("Working directory must be set");
 
         // Create snapshots.
         for i in 0..count {
@@ -124,12 +127,16 @@ impl Scenario for SnapshotPaths {
 
         {
             let kvs = kvs_instance(params).expect("Failed to create KVS instance");
-
-            let kvs_path_result = kvs.get_kvs_filename(SnapshotId(snapshot_id));
-            let hash_path_result = kvs.get_hash_filename(SnapshotId(snapshot_id));
+            let (kvs_path, hash_path) = kvs_hash_paths(
+                &working_dir,
+                kvs.parameters().instance_id,
+                SnapshotId(snapshot_id),
+            );
             info!(
-                kvs_path = format!("{kvs_path_result:?}"),
-                hash_path = format!("{hash_path_result:?}")
+                kvs_path = to_str(&kvs_path),
+                kvs_path_exists = kvs_path.exists(),
+                hash_path = to_str(&hash_path),
+                hash_path_exists = hash_path.exists(),
             );
         }
 

--- a/tests/rust_test_scenarios/src/helpers/kvs_instance.rs
+++ b/tests/rust_test_scenarios/src/helpers/kvs_instance.rs
@@ -1,29 +1,51 @@
 //! KVS instance test helpers.
 
 use crate::helpers::kvs_parameters::KvsParameters;
-use rust_kvs::prelude::{ErrorCode, Kvs, KvsBuilder};
+use rust_kvs::prelude::{ErrorCode, Kvs, KvsBuilder, KvsMap, KvsValue};
 
 /// Create KVS instance based on provided parameters.
 pub fn kvs_instance(kvs_parameters: KvsParameters) -> Result<Kvs, ErrorCode> {
-    let mut builder = KvsBuilder::new(kvs_parameters.instance_id);
+    let mut kvs_builder = KvsBuilder::new(kvs_parameters.instance_id);
 
+    // Set `defaults` mode.
     if let Some(flag) = kvs_parameters.defaults {
-        builder = builder.defaults(flag);
+        kvs_builder = kvs_builder.defaults(flag);
     }
 
+    // Set `kvs_load` mode.
     if let Some(flag) = kvs_parameters.kvs_load {
-        builder = builder.kvs_load(flag);
+        kvs_builder = kvs_builder.kvs_load(flag);
     }
 
+    // Set `backend_parameters`.
+    let mut backend_parameters =
+        KvsMap::from([("name".to_string(), KvsValue::String("json".to_string()))]);
+    let mut set_backend = false;
+
+    // Set working directory.
     if let Some(dir) = kvs_parameters.dir {
-        builder = builder.dir(dir.to_string_lossy().to_string());
+        backend_parameters.insert(
+            "working_dir".to_string(),
+            KvsValue::String(dir.to_string_lossy().to_string()),
+        );
+        set_backend = true;
     }
 
+    // Set max number of snapshots.
     if let Some(snapshot_max_count) = kvs_parameters.snapshot_max_count {
-        builder = builder.snapshot_max_count(snapshot_max_count);
+        backend_parameters.insert(
+            "snapshot_max_count".to_string(),
+            KvsValue::U64(snapshot_max_count as u64),
+        );
+        set_backend = true;
     }
 
-    let kvs: Kvs = builder.build()?;
+    // Set backend, if backend parameters were provided.
+    if set_backend {
+        kvs_builder = kvs_builder.backend_parameters(backend_parameters);
+    }
+
+    let kvs: Kvs = kvs_builder.build()?;
 
     Ok(kvs)
 }

--- a/tests/rust_test_scenarios/src/helpers/mod.rs
+++ b/tests/rust_test_scenarios/src/helpers/mod.rs
@@ -1,7 +1,22 @@
+use rust_kvs::prelude::{InstanceId, SnapshotId};
+use std::path::{Path, PathBuf};
+
 pub mod kvs_instance;
 pub mod kvs_parameters;
 
 /// Helper function to convert `Debug`-typed value to `String`.
 pub(crate) fn to_str<T: std::fmt::Debug>(value: &T) -> String {
     format!("{value:?}")
+}
+
+/// Helper function to get expected KVS and hash file paths.
+pub(crate) fn kvs_hash_paths(
+    working_dir: &Path,
+    instance_id: InstanceId,
+    snapshot_id: SnapshotId,
+) -> (PathBuf, PathBuf) {
+    let kvs_path = working_dir.join(format!("kvs_{instance_id}_{snapshot_id}.json"));
+    let hash_path = working_dir.join(format!("kvs_{instance_id}_{snapshot_id}.hash"));
+
+    (kvs_path, hash_path)
 }

--- a/tests/rust_test_scenarios/src/test_basic.rs
+++ b/tests/rust_test_scenarios/src/test_basic.rs
@@ -1,3 +1,4 @@
+use crate::helpers::kvs_instance::kvs_instance;
 use crate::helpers::kvs_parameters::KvsParameters;
 use rust_kvs::prelude::*;
 use test_scenarios_rust::scenario::Scenario;
@@ -22,20 +23,8 @@ impl Scenario for BasicScenario {
 
         let params = KvsParameters::from_json(input_string).expect("Failed to parse parameters");
 
-        // Set builder parameters.
-        let mut builder = KvsBuilder::new(params.instance_id);
-        if let Some(flag) = params.defaults {
-            builder = builder.defaults(flag);
-        }
-        if let Some(flag) = params.kvs_load {
-            builder = builder.kvs_load(flag);
-        }
-        if let Some(dir) = params.dir {
-            builder = builder.dir(dir.to_string_lossy().to_string());
-        }
-
         // Create KVS.
-        let kvs: Kvs = builder.build().expect("Failed to build KVS instance");
+        let kvs = kvs_instance(params).expect("Failed to create KVS instance");
 
         // Simple set/get.
         let key = "example_key";


### PR DESCRIPTION
- Created new `KvsBackend` API.
  - No longer filesystem-specific.
- Added `KvsBackendRegistry`.
  - `KvsBuilder` accepts backend parameters using `KvsMap`.
- `JsonBackend` used as default.
- Built-in backend access is not hidden.
- `backend_registration` example.
- PlantUML-based class diagram.
- Updated tests.