### PR TITLE
impl: allow unset params in `KvsBuilder`

### DIFF
--- a/src/rust/rust_kvs/src/kvs.rs
+++ b/src/rust/rust_kvs/src/kvs.rs
@@ -38,6 +38,18 @@ pub struct KvsParameters {
     pub snapshot_max_count: usize,
 }
 
+impl KvsParameters {
+    pub fn new(instance_id: InstanceId) -> Self {
+        Self {
+            instance_id,
+            defaults: KvsDefaults::Optional,
+            kvs_load: KvsLoad::Optional,
+            working_dir: PathBuf::new(),
+            snapshot_max_count: 3,
+        }
+    }
+}
+
 /// Key-value-storage data
 pub struct GenericKvs<Backend: KvsBackend, PathResolver: KvsPathResolver = Backend> {
     /// KVS instance data.


### PR DESCRIPTION
If `KvsBuilder` param is not set - either default is used, or value from existing instance.
No longer it is required to know what params were originally used - instance can be simply created without any.