### PR TITLE
score_tooling: Switch and update

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -11,12 +11,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@score_cli_helper//:cli_helper.bzl", "cli_helper")
-load("@score_cr_checker//:cr_checker.bzl", "copyright_checker")
-load("@score_dash_license_checker//:dash.bzl", "dash_license_checker")
 load("@score_docs_as_code//:docs.bzl", "docs")
-load("@score_format_checker//:macros.bzl", "use_format_targets")
-load("@score_starpls_lsp//:starpls.bzl", "setup_starpls")
+load("@score_tooling//:defs.bzl", "cli_helper", "copyright_checker", "dash_license_checker", "setup_starpls", "use_format_targets")
 load("//:project_config.bzl", "PROJECT_CONFIG")
 
 # Creates all documentation targets:
@@ -41,8 +37,8 @@ copyright_checker(
         "//:BUILD",
         "//:MODULE.bazel",
     ],
-    config = "@score_cr_checker//resources:config",
-    template = "@score_cr_checker//resources:templates",
+    config = "@score_tooling//cr_checker/resources:config",
+    template = "@score_tooling//cr_checker/resources:templates",
     visibility = ["//visibility:public"],
 )
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -70,19 +70,11 @@ bazel_dep(name = "googletest", version = "1.15.0")
 bazel_dep(name = "google_benchmark", version = "1.9.4")
 
 ## S-CORE bazel registry
-# Checker rule for CopyRight checks/fixs
-bazel_dep(name = "score_cr_checker", version = "0.3.1")
+bazel_dep(name = "score_tooling", version = "1.0.2")
 
-# Starlark language server
-bazel_dep(name = "score_starpls_lsp", version = "0.1.0")
-
-#Dash license checker
-bazel_dep(name = "score_dash_license_checker", version = "0.1.2")
-
-# Format checker
-bazel_dep(name = "score_format_checker", version = "0.1.1")
-bazel_dep(name = "aspect_rules_lint", version = "1.4.4")
-bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
+# ToDo: implicit dependencies for score_tooling, but needed directly here??
+bazel_dep(name = "aspect_rules_lint", version = "1.10.2", dev_dependency = True)
+bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2", dev_dependency = True)
 
 # docs-as-code
 bazel_dep(name = "score_docs_as_code", version = "1.0.1")
@@ -91,9 +83,6 @@ bazel_dep(name = "score_docs_as_code", version = "1.0.1")
 bazel_dep(name = "score_python_basics", version = "0.3.4")
 bazel_dep(name = "score_platform", version = "0.3.0")
 bazel_dep(name = "score_process", version = "1.1.0")
-
-# cli helper
-bazel_dep(name = "score_cli_helper", version = "0.1.2")
 
 # Module deps
 bazel_dep(name = "score-baselibs", version = "0.0.0")


### PR DESCRIPTION
Switch to the module bundling various score tools score_tooling 1.0.2. Remove handling of the previous individual used ones:
- score_cli_helper
- score_cr_checker
- score_dash_license_checker
- score_format_checker
- score_starpls_lsp