### PR TITLE
rust: Update toolchain and dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,12 +38,22 @@ pip.parse(
 use_repo(pip, "pip_score_venv_test")
 
 # rust
-bazel_dep(name = "rules_rust", version = "0.56.0")
+bazel_dep(name = "rules_rust", version = "0.67.0")
 
 rust = use_extension("@rules_rust//rust:extensions.bzl", "rust")
 rust.toolchain(
-    edition = "2021",
-    versions = ["1.85.0"],
+    edition = "2024",
+    versions = ["1.90.0"],
+)
+
+# ToDo: Official release needed, documentaion on usage of rust toolchains missing
+bazel_dep(name = "rust_qnx8_toolchain", version = "1.2.0", dev_dependency = True)
+archive_override(
+    module_name = "rust_qnx8_toolchain",
+    strip_prefix = "qnx8",
+    urls = [
+        "https://github.com/qorix-group/rust-lang-qnx8/releases/download/1.2.0/qnx8_rust_toolchain.tar.gz",
+    ],
 )
 
 # LLVM Toolchains Rules - host configuration
@@ -110,16 +120,6 @@ crate.from_cargo(
         "//tests/rust_test_scenarios:Cargo.toml",
     ],
 )
-
-bazel_dep(name = "rust_qnx8_toolchain", version = "1.0.0", dev_dependency = True)
-archive_override(
-    module_name = "rust_qnx8_toolchain",
-    strip_prefix = "qnx8",
-    urls = [
-        "https://github.com/qorix-group/rust-lang-qnx8/releases/download/1.0.0/qnx8_rust_toolchain.tar.gz",
-    ],
-)
-
 use_repo(crate, "score_persistency_crates")
 
 ## temporary overrides / tools

--- a/src/rust/rust_kvs/src/kvs_value.rs
+++ b/src/rust/rust_kvs/src/kvs_value.rs
@@ -90,7 +90,7 @@ macro_rules! impl_tryfrom_kvs_value_to_t {
         impl std::convert::TryFrom<&KvsValue> for $to {
             type Error = String;
             fn try_from(value: &KvsValue) -> Result<Self, Self::Error> {
-                if let KvsValue::$variant(ref n) = value {
+                if let KvsValue::$variant(n) = value {
                     Ok(n.clone())
                 } else {
                     Err(format!("KvsValue is not a {}", stringify!($to)))


### PR DESCRIPTION
- rules_rust 0.56.0 -> 0.67.0
- rust.toolchain edition 2021 -> 2024, version 1.85.0 -> 1.90.0
- rust_qnx8_toolchain 1.0.0 -> 1.2.0

Needs backward compatible fix for ref handling.