### PR TITLE
score_docs_as_code: Update to 2.0.2

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -18,7 +18,8 @@ module(
 
 ## Toolchains (dependencies and config)
 # python
-bazel_dep(name = "rules_python", version = "1.4.1")
+# ToDo: score_docs_as_code broken with any later version >1.4.1 (e.g. 1.6.3)
+bazel_dep(name = "rules_python", version = "1.4.1", dev_dependency = True)
 
 PYTHON_VERSION = "3.12"
 
@@ -79,7 +80,7 @@ bazel_dep(name = "aspect_rules_lint", version = "1.10.2")
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
 
 # docs-as-code
-bazel_dep(name = "score_docs_as_code", version = "2.0.1")
+bazel_dep(name = "score_docs_as_code", version = "2.0.2")
 
 # Provides, pytest & venv
 bazel_dep(name = "score_python_basics", version = "0.3.4")


### PR DESCRIPTION
- score_docs_as_code 2.0.1 -> 2.0.2
- rules_python needs to stay to 1.4.1 (but dev_dependency)