### PR TITLE
fix: remove dev_dependency flag from google_benchmark

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -69,7 +69,7 @@ register_toolchains(
 # Module dependencies
 bazel_dep(name = "googletest", version = "1.17.0.bcr.1")
 
-bazel_dep(name = "google_benchmark", version = "1.9.4", dev_dependency = True)
+bazel_dep(name = "google_benchmark", version = "1.9.4")
 
 ## S-CORE bazel registry
 bazel_dep(name = "score_tooling", version = "1.0.2")


### PR DESCRIPTION
google_benchmark cannot be a dev_dependency. Rules for dev_dependency still not understood.... but we need this fix in reference_integration, otherwise it does not work at all.