### PR TITLE
Feature/kvs compiletime max size support

### DIFF
--- a/src/cpp/src/kvs.cpp
+++ b/src/cpp/src/kvs.cpp
@@ -15,6 +15,7 @@
 #include <sstream>
 #include "internal/kvs_helper.hpp"
 #include "kvs.hpp"
+#include <filesystem>
 
 //TODO Default Value Handling TBD
 //TODO Add Score Logging


### PR DESCRIPTION
This pull request introduces support for specifying the maximum size of the Key-Value Storage (KVS) at compile time, fulfilling the related requirement:

"The Key-Value-Storage shall support specification of its maximum size at compile time."

and resolves [issue #161](https://github.com/eclipse-score/persistency/issues/161)
