### PR TITLE
impl: use hash file for defaults

### DIFF
--- a/src/rust/rust_kvs/src/kvs.rs
+++ b/src/rust/rust_kvs/src/kvs.rs
@@ -393,7 +393,7 @@ impl<Backend: KvsBackend, PathResolver: KvsPathResolver> KvsApi
         );
 
         let data = self.data.lock()?;
-        Backend::save_kvs(&data.kvs_map, &kvs_path, Some(&hash_path)).map_err(|e| {
+        Backend::save_kvs(&data.kvs_map, &kvs_path, &hash_path).map_err(|e| {
             eprintln!("error: save_kvs failed: {e:?}");
             e
         })?;
@@ -473,7 +473,7 @@ impl<Backend: KvsBackend, PathResolver: KvsPathResolver> KvsApi
             self.parameters.instance_id,
             snapshot_id,
         );
-        data.kvs_map = Backend::load_kvs(&kvs_path, Some(&hash_path))?;
+        data.kvs_map = Backend::load_kvs(&kvs_path, &hash_path)?;
 
         Ok(())
     }
@@ -530,7 +530,7 @@ mod kvs_tests {
     use crate::kvs_backend::{KvsBackend, KvsPathResolver};
     use crate::kvs_builder::KvsData;
     use crate::kvs_value::{KvsMap, KvsValue};
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::{Arc, Mutex};
     use tempfile::tempdir;
 
@@ -539,17 +539,14 @@ mod kvs_tests {
     struct MockBackend;
 
     impl KvsBackend for MockBackend {
-        fn load_kvs(
-            _kvs_path: &std::path::Path,
-            _hash_path: Option<&PathBuf>,
-        ) -> Result<KvsMap, ErrorCode> {
+        fn load_kvs(_kvs_path: &Path, _hash_path: &Path) -> Result<KvsMap, ErrorCode> {
             unimplemented!()
         }
 
         fn save_kvs(
             _kvs_map: &KvsMap,
-            _kvs_path: &std::path::Path,
-            _hash_path: Option<&PathBuf>,
+            _kvs_path: &Path,
+            _hash_path: &Path,
         ) -> Result<(), ErrorCode> {
             unimplemented!()
         }
@@ -561,7 +558,7 @@ mod kvs_tests {
         }
 
         fn kvs_file_path(
-            _working_dir: &std::path::Path,
+            _working_dir: &Path,
             _instance_id: InstanceId,
             _snapshot_id: SnapshotId,
         ) -> PathBuf {
@@ -573,7 +570,7 @@ mod kvs_tests {
         }
 
         fn hash_file_path(
-            _working_dir: &std::path::Path,
+            _working_dir: &Path,
             _instance_id: InstanceId,
             _snapshot_id: SnapshotId,
         ) -> PathBuf {
@@ -584,7 +581,15 @@ mod kvs_tests {
             unimplemented!()
         }
 
-        fn defaults_file_path(_working_dir: &std::path::Path, _instance_id: InstanceId) -> PathBuf {
+        fn defaults_file_path(_working_dir: &Path, _instance_id: InstanceId) -> PathBuf {
+            unimplemented!()
+        }
+
+        fn defaults_hash_file_name(_instance_id: InstanceId) -> String {
+            unimplemented!()
+        }
+
+        fn defaults_hash_file_path(_working_dir: &Path, _instance_id: InstanceId) -> PathBuf {
             unimplemented!()
         }
     }

--- a/src/rust/rust_kvs/src/kvs_backend.rs
+++ b/src/rust/rust_kvs/src/kvs_backend.rs
@@ -17,14 +17,10 @@ use std::path::{Path, PathBuf};
 /// KVS backend interface.
 pub trait KvsBackend {
     /// Load KvsMap from given file.
-    fn load_kvs(kvs_path: &Path, hash_path: Option<&PathBuf>) -> Result<KvsMap, ErrorCode>;
+    fn load_kvs(kvs_path: &Path, hash_path: &Path) -> Result<KvsMap, ErrorCode>;
 
     /// Store KvsMap at given file path.
-    fn save_kvs(
-        kvs_map: &KvsMap,
-        kvs_path: &Path,
-        hash_path: Option<&PathBuf>,
-    ) -> Result<(), ErrorCode>;
+    fn save_kvs(kvs_map: &KvsMap, kvs_path: &Path, hash_path: &Path) -> Result<(), ErrorCode>;
 }
 
 /// KVS path resolver interface.
@@ -54,4 +50,10 @@ pub trait KvsPathResolver {
 
     /// Get defaults file path in working directory.
     fn defaults_file_path(working_dir: &Path, instance_id: InstanceId) -> PathBuf;
+
+    /// Get defaults hash file name.
+    fn defaults_hash_file_name(instance_id: InstanceId) -> String;
+
+    /// Get defaults hash file path in working directory.
+    fn defaults_hash_file_path(working_dir: &Path, instance_id: InstanceId) -> PathBuf;
 }

--- a/tests/python_test_cases/tests/test_cit_default_values.py
+++ b/tests/python_test_cases/tests/test_cit_default_values.py
@@ -14,6 +14,7 @@ import json
 import re
 from pathlib import Path
 from typing import Any, Generator
+from zlib import adler32
 
 import pytest
 from testing_utils import LogContainer, ScenarioResult
@@ -43,18 +44,27 @@ def create_defaults_file(
     dir_path: Path, instance_id: int, values: dict[str, TaggedValue]
 ) -> Path:
     """
-    Create file containing default values.
+    Create file containing default values, along with a matching hash file.
+    Returns path to default values file.
     """
     # Path to expected defaults file.
     # E.g., `/tmp/xyz/kvs_0_default.json`.
     defaults_file_path = dir_path / f"kvs_{instance_id}_default.json"
+    # Path to expected defaults hash file.
+    # E.g., `/tmp/xyz/kvs_0_default.hash`.
+    defaults_hash_file_path = dir_path / f"kvs_{instance_id}_default.hash"
 
     # Create JSON string containing default values.
     json_str = create_defaults_json(values)
 
-    # Save to file.
+    # Generate hash.
+    hash = adler32(json_str.encode()).to_bytes(length=4, byteorder="big")
+
+    # Save content and hash.
     with open(defaults_file_path, mode="w", encoding="UTF-8") as file:
         file.write(json_str)
+    with open(defaults_hash_file_path, mode="wb") as file:
+        file.write(hash)
 
     return defaults_file_path
 


### PR DESCRIPTION
Resolve #170 

- Require hash file for default files.
- Make hash parameter non-optional.
- Update tests.