### PR TITLE
fix: resolve Python venv package collision and missing config target

### DIFF
--- a/tests/python_test_cases/BUILD
+++ b/tests/python_test_cases/BUILD
@@ -11,8 +11,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 load("@pip_score_venv_test//:requirements.bzl", "all_requirements")
+load("@rules_python//python:defs.bzl", "py_library")
 load("@rules_python//python:pip.bzl", "compile_pip_requirements")
 load("@score_python_basics//:defs.bzl", "score_py_pytest", "score_virtualenv")
+
+# Empty config library required by score_virtualenv macro
+py_library(
+    name = "config",
+    srcs = [],
+)
 
 # Additional requirements for the tests
 compile_pip_requirements(
@@ -24,9 +31,10 @@ compile_pip_requirements(
     ],
 )
 
+# Test specific dependencies are specified in the test targets below
 score_virtualenv(
     name = "python_tc_venv",
-    reqs = all_requirements,
+    reqs = [],
     venv_name = ".python_tc_venv",
 )
 


### PR DESCRIPTION
Fixed build failures in python_test_cases virtual environment setup:

 * Added empty py_library(name="config") required by score_virtualenv macro which has hardcoded dependency on :config with PyInfo provider

 * Set score_virtualenv reqs=[] to avoid package collisions