### PR TITLE
impl: prefer `core` to `std`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "tests/rust_test_scenarios",
 ]
 
+
 [workspace.package]
 version = "0.1.0"
 edition = "2021"
@@ -18,3 +19,12 @@ rust_kvs_tool = { path = "src/rust/rust_kvs_tool" }
 adler32 = "1.2.0"
 tinyjson = "2.5.1"
 pico-args = "0.5"
+
+
+[workspace.lints.clippy]
+std_instead_of_core = "warn"
+alloc_instead_of_core = "warn"
+
+
+[workspace.lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }

--- a/src/rust/rust_kvs/Cargo.toml
+++ b/src/rust/rust_kvs/Cargo.toml
@@ -3,12 +3,15 @@ name = "rust_kvs"
 version.workspace = true
 edition.workspace = true
 
+
 [dependencies]
 adler32.workspace = true
 tinyjson.workspace = true
 
+
 [dev-dependencies]
 tempfile = "3.20"
 
-[lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(coverage_nightly)'] }
+
+[lints]
+workspace = true

--- a/src/rust/rust_kvs/examples/custom_types.rs
+++ b/src/rust/rust_kvs/examples/custom_types.rs
@@ -1,9 +1,10 @@
-/// Example for custom types usage for KVS, with serialization and deserialization.
-/// - Implementing serialization/deserialization traits for custom types.
-/// - Handling external and nested types.
-/// - Usage with KVS.
+//! Example for custom types usage for KVS, with serialization and deserialization.
+//! - Implementing serialization/deserialization traits for custom types.
+//! - Handling external and nested types.
+//! - Usage with KVS.
+
+use core::net::IpAddr;
 use rust_kvs::prelude::*;
-use std::net::IpAddr;
 use tempfile::tempdir;
 
 /// `Point` is used as an example of nested serializable objects.

--- a/src/rust/rust_kvs/src/kvs.rs
+++ b/src/rust/rust_kvs/src/kvs.rs
@@ -14,8 +14,8 @@ use crate::kvs_api::{InstanceId, KvsApi, KvsDefaults, KvsLoad, SnapshotId};
 use crate::kvs_backend::{KvsBackend, KvsPathResolver};
 use crate::kvs_builder::KvsData;
 use crate::kvs_value::{KvsMap, KvsValue};
+use core::marker::PhantomData;
 use std::fs;
-use std::marker::PhantomData;
 use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 
@@ -243,8 +243,8 @@ impl<Backend: KvsBackend, PathResolver: KvsPathResolver> KvsApi
     ///   * `ErrorCode::KeyNotFound`: Key wasn't found in KVS nor in defaults
     fn get_value_as<T>(&self, key: &str) -> Result<T, ErrorCode>
     where
-        for<'a> T: TryFrom<&'a KvsValue> + std::clone::Clone,
-        for<'a> <T as TryFrom<&'a KvsValue>>::Error: std::fmt::Debug,
+        for<'a> T: TryFrom<&'a KvsValue> + core::clone::Clone,
+        for<'a> <T as TryFrom<&'a KvsValue>>::Error: core::fmt::Debug,
     {
         let data = self.data.lock()?;
         if let Some(value) = data.kvs_map.get(key) {

--- a/src/rust/rust_kvs/src/kvs_api.rs
+++ b/src/rust/rust_kvs/src/kvs_api.rs
@@ -81,7 +81,7 @@ pub trait KvsApi {
     fn get_value_as<T>(&self, key: &str) -> Result<T, ErrorCode>
     where
         for<'a> T: TryFrom<&'a KvsValue> + Clone,
-        for<'a> <T as TryFrom<&'a KvsValue>>::Error: std::fmt::Debug;
+        for<'a> <T as TryFrom<&'a KvsValue>>::Error: core::fmt::Debug;
     fn get_default_value(&self, key: &str) -> Result<KvsValue, ErrorCode>;
     fn is_value_default(&self, key: &str) -> Result<bool, ErrorCode>;
     fn set_value<S: Into<String>, J: Into<KvsValue>>(

--- a/src/rust/rust_kvs/src/kvs_builder.rs
+++ b/src/rust/rust_kvs/src/kvs_builder.rs
@@ -14,7 +14,7 @@ use crate::kvs::{GenericKvs, KvsParameters};
 use crate::kvs_api::{InstanceId, KvsDefaults, KvsLoad, SnapshotId};
 use crate::kvs_backend::{KvsBackend, KvsPathResolver};
 use crate::kvs_value::KvsMap;
-use std::marker::PhantomData;
+use core::marker::PhantomData;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock, Mutex, MutexGuard, PoisonError};
 
@@ -323,7 +323,7 @@ mod kvs_builder_tests {
     use crate::kvs_backend::{KvsBackend, KvsPathResolver};
     use crate::kvs_builder::{GenericKvsBuilder, KVS_MAX_INSTANCES, KVS_POOL};
     use crate::kvs_value::{KvsMap, KvsValue};
-    use std::ops::DerefMut;
+    use core::ops::DerefMut;
     use std::path::{Path, PathBuf};
     use std::sync::{LazyLock, Mutex, MutexGuard};
     use tempfile::tempdir;

--- a/src/rust/rust_kvs/src/kvs_mock.rs
+++ b/src/rust/rust_kvs/src/kvs_mock.rs
@@ -80,7 +80,7 @@ impl KvsApi for MockKvs {
     fn get_value_as<T>(&self, key: &str) -> Result<T, ErrorCode>
     where
         for<'a> T: TryFrom<&'a KvsValue> + Clone,
-        for<'a> <T as TryFrom<&'a KvsValue>>::Error: std::fmt::Debug,
+        for<'a> <T as TryFrom<&'a KvsValue>>::Error: core::fmt::Debug,
     {
         if self.fail {
             return Err(ErrorCode::UnmappedError);

--- a/src/rust/rust_kvs/src/kvs_value.rs
+++ b/src/rust/rust_kvs/src/kvs_value.rs
@@ -9,8 +9,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// TryFrom<&KvsValue> for all supported types
-use std::convert::TryFrom;
+use core::convert::TryFrom;
 
 /// Key-value storage map type
 pub type KvsMap = std::collections::HashMap<String, KvsValue>;
@@ -87,7 +86,7 @@ impl From<()> for KvsValue {
 // Macro to implement TryFrom<&KvsValue> for T for each supported type/variant.
 macro_rules! impl_tryfrom_kvs_value_to_t {
     ($to:ty, $variant:ident) => {
-        impl std::convert::TryFrom<&KvsValue> for $to {
+        impl core::convert::TryFrom<&KvsValue> for $to {
             type Error = String;
             fn try_from(value: &KvsValue) -> Result<Self, Self::Error> {
                 if let KvsValue::$variant(ref n) = value {

--- a/src/rust/rust_kvs/tests/common/mod.rs
+++ b/src/rust/rust_kvs/tests/common/mod.rs
@@ -4,7 +4,7 @@
 // This is to ensure file is not improperly detected as empty test file.
 
 use rust_kvs::kvs_value::KvsValue;
-use std::iter::zip;
+use core::iter::zip;
 
 /// Compare `KvsValue` objects.
 ///

--- a/src/rust/rust_kvs_tool/Cargo.toml
+++ b/src/rust/rust_kvs_tool/Cargo.toml
@@ -8,7 +8,12 @@ edition.workspace = true
 name = "kvs_tool"
 path = "src/kvs_tool.rs"
 
+
 [dependencies]
 rust_kvs.workspace = true
 tinyjson.workspace = true
 pico-args.workspace = true
+
+
+[lints]
+workspace = true

--- a/tests/rust_test_scenarios/Cargo.toml
+++ b/tests/rust_test_scenarios/Cargo.toml
@@ -3,6 +3,7 @@ name = "rust_test_scenarios"
 version.workspace = true
 edition.workspace = true
 
+
 [dependencies]
 rust_kvs.workspace = true
 tinyjson.workspace = true
@@ -11,3 +12,7 @@ tracing-subscriber = { version = "0.3.19", features = ["json"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.140"
 test_scenarios_rust = { git = "https://github.com/qorix-group/testing_tools.git", tag = "v0.2.0" }
+
+
+[lints]
+workspace = true

--- a/tests/rust_test_scenarios/src/helpers/mod.rs
+++ b/tests/rust_test_scenarios/src/helpers/mod.rs
@@ -2,6 +2,6 @@ pub mod kvs_instance;
 pub mod kvs_parameters;
 
 /// Helper function to convert `Debug`-typed value to `String`.
-pub(crate) fn to_str<T: std::fmt::Debug>(value: &T) -> String {
+pub(crate) fn to_str<T: core::fmt::Debug>(value: &T) -> String {
     format!("{value:?}")
 }


### PR DESCRIPTION
- Add linters to prefer `core` to `std`.
- Replace `std` usage with `core`.