### PR TITLE
Refactor self-move warning suppression

### DIFF
--- a/src/cpp/tests/test_kvs.cpp
+++ b/src/cpp/tests/test_kvs.cpp
@@ -36,15 +36,10 @@ TEST(kvs_constructor, move_constructor) {
     #if defined(__clang__)
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wself-move"
-    #elif defined(__GNUC__)
-    #pragma GCC diagnostic push
-    #pragma GCC diagnostic ignored "-Wself-move"
     #endif
     kvs_a = std::move(kvs_a);  /* Intentional self-move */
     #if defined(__clang__)
     #pragma clang diagnostic pop
-    #elif defined(__GNUC__)
-    #pragma GCC diagnostic pop
     #endif
 
 


### PR DESCRIPTION
Removed GCC specific pragma for self-move warning suppression, in score gcc version 12 is used and the warning is not available in this version
Fixes: https://github.com/eclipse-score/persistency/issues/180