### PR TITLE
bazel: fix module integration

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -88,12 +88,8 @@ bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "score_baselibs", version = "0.1.2")
 bazel_dep(name = "score_bazel_platforms", version = "0.0.2")
 bazel_dep(name = "score_docs_as_code", version = "2.2.0")
-bazel_dep(name = "score_platform", version = "0.5.0")
-git_override(
-    module_name = "score_platform",
-    commit = "9d30b718db22ad335cccbcfd72f96e5b37fa58f1",  # obsolete by 0.5.1+
-    remote = "https://github.com/eclipse-score/score.git",
-)
+
+bazel_dep(name = "score_platform", version = "0.5.2", dev_dependency = True)
 
 bazel_dep(name = "score_process", version = "1.3.2")
 bazel_dep(name = "score_python_basics", version = "0.3.4")


### PR DESCRIPTION
add dev dependecies to avoid collisions

# Bugfix

> [!IMPORTANT]
> Use this template only for bugfixes that do not influence topics covered by contribution requests or improvements.

> [!CAUTION]
> Make sure to submit your pull-request as **Draft** until you are ready to have it reviewed by the Committers.

## Description

Non dev dependencies were causing issues to python environment in `reference_integration` repository and did not allow creating venv resulting in failing pipelines.
## Related ticket

> [!IMPORTANT]
> Please replace `[ISSUE-NUMBER]` with the issue-number that tracks this bug fix. If there is no such
> ticket yet, create one via [this issue template](../ISSUE_TEMPLATE/new?template=bug_fix.md).

Relates: https://github.com/eclipse-score/reference_integration/issues/53
