### PR TITLE
MODULE.bazel: Update various dependencies

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -38,7 +38,7 @@ pip.parse(
 use_repo(pip, "pip_score_venv_test")
 
 # rust
-bazel_dep(name = "rules_rust", version = "0.56.0")
+bazel_dep(name = "rules_rust", version = "0.61.0")
 
 # Shared Rust policies (Clippy config, etc.), overridden locally during development.
 bazel_dep(name = "score_rust_policies", version = "0.0.2", dev_dependency = True)
@@ -50,7 +50,7 @@ rust.toolchain(
 )
 
 # bazel cc rules
-bazel_dep(name = "rules_cc", version = "0.1.1")
+bazel_dep(name = "rules_cc", version = "0.1.2")
 
 #score gcc toolchain
 bazel_dep(name = "score_toolchains_gcc", version = "0.5", dev_dependency = True)
@@ -90,12 +90,12 @@ bazel_dep(name = "aspect_rules_lint", version = "1.10.2")
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
 
 # docs-as-code
-bazel_dep(name = "score_docs_as_code", version = "2.0.1")
+bazel_dep(name = "score_docs_as_code", version = "2.2.0")
 
 # Provides, pytest & venv
 bazel_dep(name = "score_python_basics", version = "0.3.4")
-bazel_dep(name = "score_platform", version = "0.4.1")
-bazel_dep(name = "score_process", version = "1.3.1")
+bazel_dep(name = "score_platform", version = "0.5.0")
+bazel_dep(name = "score_process", version = "1.3.2")
 
 # Module deps
 bazel_dep(name = "score_baselibs", version = "0.1.2")
@@ -176,7 +176,7 @@ archive_override(
     ],
 )
 
-bazel_dep(name = "platforms", version = "0.0.11")
+bazel_dep(name = "platforms", version = "1.0.0")
 
 # Registers the custom Rust toolchain wired to @qnx_rust
 register_toolchains(


### PR DESCRIPTION
For the preparation of v0.5-beta update score_docs_as_code to 2.2.0. Also update the related dependencies score_platform and score_process. Additional updates for standard bazel modules which would be used anyways due to the dependencies.