### PR TITLE
Adapt for usage of score toolchains

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,25 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# -------------------------------------------------------------------------------
+# Links to S-CORE Bazel registry and Bazel Central Regoe
+# -------------------------------------------------------------------------------
+common --registry=https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/
+common --registry=https://bcr.bazel.build
+
+# -------------------------------------------------------------------------------
+# Default build flags (all configurations)
+# -------------------------------------------------------------------------------
 build --java_language_version=17
 build --tool_java_language_version=17
 build --java_runtime_version=remotejdk_17
@@ -10,14 +32,44 @@ build --@score_baselibs//score/mw/log/flags:KRemote_Logging=False
 build --@score-baselibs//score/json:base_library=nlohmann
 build --@score-baselibs//score/mw/log/flags:KRemote_Logging=False
 
-test --test_output=errors
-
-common --registry=https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/
-common --registry=https://bcr.bazel.build
-
 # Clippy linting (enabled by default)
 build --aspects=@rules_rust//rust:defs.bzl%rust_clippy_aspect
 build --output_groups=+clippy_checks
 build --@rules_rust//rust/settings:clippy.toml=@score_rust_policies//clippy/strict:clippy.toml
 
+test --test_output=errors
+
+# -------------------------------------------------------------------------------
+# Shared configuration for simple test execution
+# -------------------------------------------------------------------------------
+build:per_shared --incompatible_strict_action_env
+build:per_shared --sandbox_writable_path=/var/tmp
+build:per_shared --host_platform=@score_bazel_platforms//:x86_64-linux
+
+# -------------------------------------------------------------------------------
+# Config dedicated to host platform CPU:x86_64 and OS:Linux
+# -------------------------------------------------------------------------------
+build:per-x86_64-linux --config=per_shared
+build:per-x86_64-linux --platforms=@score_bazel_platforms//:x86_64-linux
+build:per-x86_64-linux --extra_toolchains=@gcc_toolchain//:host_gcc_12
+
+# -------------------------------------------------------------------------------
+# Config dedicated to target platform CPU:x86_64 and OS:QNX
+# -------------------------------------------------------------------------------
+build:per-x86_64-qnx --config=per_shared
+build:per-x86_64-qnx --platforms=@score_toolchains_qnx//platforms:x86_64-qnx
+build:per-x86_64-qnx --extra_toolchains=@toolchains_qnx_qcc//:qcc_x86_64
+build:per-x86_64-qnx --extra_toolchains=@toolchains_qnx_ifs//:ifs_x86_64
+
+# -------------------------------------------------------------------------------
+# Config dedicated to target platform CPU:arm64 and OS:QNX
+# -------------------------------------------------------------------------------
+build:per-arm64-qnx --config=per_shared
+build:per-arm64-qnx --platforms=@score_toolchains_qnx//platforms:aarch64-qnx8_0
+build:per-arm64-qnx --extra_toolchains=@toolchains_qnx_qcc//:qcc_aarch64
+build:per-arm64-qnx --extra_toolchains=@toolchains_qnx_ifs//:ifs_aarch64
+
+# -------------------------------------------------------------------------------
+# Import local user workspace file, if exists
+# -------------------------------------------------------------------------------
 try-import %workspace%/user.bazelrc

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -146,11 +146,11 @@ jobs:
           bazelisk-cache: true
 
       - name: Bazel Build
-        run: bazel build //:kvs_cpp
+        run: bazel build --config=per-x86_64-linux //:kvs_cpp
 
       - name: Bazel Unit Test with Coverage
         run: |
-          bazel coverage //:test_kvs_cpp \
+          bazel coverage --config=per-x86_64-linux //:test_kvs_cpp \
             --collect_code_coverage \
             --combined_report=lcov \
             --experimental_generate_llvm_lcov \
@@ -184,4 +184,4 @@ jobs:
           rm ${OUT_FILE}
 
       - name: Bazel Benchmark
-        run: bazel run -c opt //:bm_kvs_cpp
+        run: bazel run --config=per-x86_64-linux -c opt //:bm_kvs_cpp

--- a/.github/workflows/component_integration_tests.yml
+++ b/.github/workflows/component_integration_tests.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Build C++ test scenarios with Bazel
         run: |
-          bazel build //tests/cpp_test_scenarios:cpp_test_scenarios
+          bazel build --config=per-x86_64-linux //tests/cpp_test_scenarios:cpp_test_scenarios
 
       - name: Build Rust test scenarios with Bazel
         run: |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -54,7 +54,6 @@ bazel_dep(name = "rules_cc", version = "0.1.2")
 
 #score gcc toolchain
 bazel_dep(name = "score_toolchains_gcc", version = "0.5", dev_dependency = True)
-
 gcc = use_extension("@score_toolchains_gcc//extentions:gcc.bzl", "gcc", dev_dependency = True)
 gcc.toolchain(
     sha256 = "8fa85c2a93a6bef1cf866fa658495a2416dfeec692e4246063b791abf18da083",
@@ -62,11 +61,6 @@ gcc.toolchain(
     url = "https://github.com/eclipse-score/toolchains_gcc_packages/releases/download/v0.0.3/x86_64-unknown-linux-gnu_gcc12.tar.gz",
 )
 use_repo(gcc, "gcc_toolchain", "gcc_toolchain_gcc")
-
-register_toolchains(
-    "@gcc_toolchain//:all",
-    dev_dependency = True,
-)
 
 ## Bazel registry
 # Module dependencies
@@ -180,13 +174,6 @@ bazel_dep(name = "platforms", version = "1.0.0")
 
 # Registers the custom Rust toolchain wired to @qnx_rust
 register_toolchains(
-    "@toolchains_qnx_qcc//:qcc_aarch64",
     "@score_toolchains_rust//toolchains/aarch64-unknown-qnx8_0:toolchain_aarch64_qnx8_0",
-    dev_dependency = True,
-)
-
-register_toolchains(
-    "@toolchains_qnx_ifs//:ifs_x86_64",
-    "@toolchains_qnx_ifs//:ifs_aarch64",
     dev_dependency = True,
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -54,6 +54,7 @@ bazel_dep(name = "rules_cc", version = "0.1.2")
 
 #score gcc toolchain
 bazel_dep(name = "score_toolchains_gcc", version = "0.5", dev_dependency = True)
+
 gcc = use_extension("@score_toolchains_gcc//extentions:gcc.bzl", "gcc", dev_dependency = True)
 gcc.toolchain(
     sha256 = "8fa85c2a93a6bef1cf866fa658495a2416dfeec692e4246063b791abf18da083",
@@ -62,13 +63,34 @@ gcc.toolchain(
 )
 use_repo(gcc, "gcc_toolchain", "gcc_toolchain_gcc")
 
+# score qnx (qcc) toolchain.
+bazel_dep(name = "score_toolchains_qnx", version = "0.0.5", dev_dependency = True)
+
+toolchains_qnx = use_extension("@score_toolchains_qnx//:extensions.bzl", "toolchains_qnx", dev_dependency = True)
+toolchains_qnx.sdp(
+    sha256 = "f2e0cb21c6baddbcb65f6a70610ce498e7685de8ea2e0f1648f01b327f6bac63",
+    strip_prefix = "installation",
+    url = "https://www.qnx.com/download/download/79858/installation.tgz",
+)
+use_repo(toolchains_qnx, "toolchains_qnx_sdp")
+use_repo(toolchains_qnx, "toolchains_qnx_qcc")
+use_repo(toolchains_qnx, "toolchains_qnx_ifs")
+
 ## Bazel registry
 # Module dependencies
 bazel_dep(name = "googletest", version = "1.17.0.bcr.1")
 
 bazel_dep(name = "google_benchmark", version = "1.9.4", dev_dependency = True)
 
+bazel_dep(name = "platforms", version = "1.0.0")
+
 ## S-CORE bazel registry
+bazel_dep(name = "score_baselibs", version = "0.1.2")
+bazel_dep(name = "score_bazel_platforms", version = "0.0.2")
+bazel_dep(name = "score_docs_as_code", version = "2.2.0")
+bazel_dep(name = "score_platform", version = "0.5.0")
+bazel_dep(name = "score_process", version = "1.3.2")
+bazel_dep(name = "score_python_basics", version = "0.3.4")
 bazel_dep(name = "score_tooling", version = "1.0.3")
 
 # ToDo: remove this once 1.0.4 is released,
@@ -82,17 +104,6 @@ git_override(
 # ToDo: implicit dependencies for score_tooling, but needed directly here??
 bazel_dep(name = "aspect_rules_lint", version = "1.10.2")
 bazel_dep(name = "buildifier_prebuilt", version = "8.2.0.2")
-
-# docs-as-code
-bazel_dep(name = "score_docs_as_code", version = "2.2.0")
-
-# Provides, pytest & venv
-bazel_dep(name = "score_python_basics", version = "0.3.4")
-bazel_dep(name = "score_platform", version = "0.5.0")
-bazel_dep(name = "score_process", version = "1.3.2")
-
-# Module deps
-bazel_dep(name = "score_baselibs", version = "0.1.2")
 
 ## additional settings / config
 crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
@@ -143,23 +154,6 @@ git_override(
     remote = "https://github.com/eclipse-score/toolchains_rust.git",
 )
 
-bazel_dep(name = "score_toolchains_qnx", version = "0.1", dev_dependency = True)
-git_override(
-    module_name = "score_toolchains_qnx",
-    commit = "cdaa451c994f5e1f88aa6395dd516586f387d0ec",
-    remote = "https://github.com/eclipse-score/toolchains_qnx.git",
-)
-
-toolchains_qnx = use_extension("@score_toolchains_qnx//:extensions.bzl", "toolchains_qnx", dev_dependency = True)
-toolchains_qnx.sdp(
-    sha256 = "f2e0cb21c6baddbcb65f6a70610ce498e7685de8ea2e0f1648f01b327f6bac63",
-    strip_prefix = "installation",
-    url = "https://www.qnx.com/download/download/79858/installation.tgz",
-)
-use_repo(toolchains_qnx, "toolchains_qnx_sdp")
-use_repo(toolchains_qnx, "toolchains_qnx_qcc")
-use_repo(toolchains_qnx, "toolchains_qnx_ifs")
-
 bazel_dep(name = "custom_qemu", version = "1.0.0", dev_dependency = True)
 archive_override(
     module_name = "custom_qemu",
@@ -169,8 +163,6 @@ archive_override(
         "https://github.com/qorix-group/custom-qemu/releases/download/1.0.0/custom_qemu.tar.gz",
     ],
 )
-
-bazel_dep(name = "platforms", version = "1.0.0")
 
 # Registers the custom Rust toolchain wired to @qnx_rust
 register_toolchains(


### PR DESCRIPTION
- Introduce configs for different platform builds (base see https://github.com/eclipse-score/persistency/pull/196) kudos to @nradakovic 
- update of score_toolchains_qnx to 0.0.5