### PR TITLE
repo: add `.clang-format` file, format C++

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,48 @@
+BasedOnStyle: Google
+AccessModifierOffset: -2
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: Empty
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortEnumsOnASingleLine: false
+# Empty is required in AllowShortFunctionsOnASingleLine over Inline because Inline contradicts with AUTOSAR rule A7-1-7
+# Such rule is no longer existing in MISRA C++:2023, once we are fully migrated to MISRA C++:2023, switching to Inline
+# could be reconsidered
+AllowShortFunctionsOnASingleLine: Empty
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: Empty
+AllowShortLoopsOnASingleLine: false
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:
+  AfterCaseLabel: true
+  AfterClass: true
+  AfterControlStatement: Always
+  AfterEnum: true
+  AfterFunction: true
+  AfterNamespace: true
+  AfterObjCDeclaration: true
+  AfterStruct: true
+  AfterUnion: true
+  BeforeCatch: true
+  BeforeElse: true
+  IndentBraces: false
+BreakBeforeBraces: Custom
+ColumnLimit: 120
+DerivePointerAlignment: false
+IncludeBlocks: Preserve
+IncludeCategories:
+  - Regex: '^(<|")(assert|complex|ctype|errno|fenv|float|inttypes|iso646|limits|locale|math|setjmp|signal|stdalign|stdargh|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|tgmath|threads|time|uchar|wchar|wctype)\.h(>|")$'
+    Priority: 2
+  - Regex: '^(<|")(cstdlib|csignal|csetjmp|cstdarg|typeinfo|typeindex|type_traits|bitset|functional|utility|ctime|chrono|cstddef|initializer_list|tuple|any|optional|variant|new|memory|scoped_allocator|memory_resource|climits|cfloat|cstdint|cinttypes|limits|exception|stdexcept|cassert|system_error|cerrno|cctype|cwctype|cstring|cwchar|cuchar|string|string_view|array|vector|deque|list|forward_list|set|map|unordered_set|unordered_map|stack|queue|algorithm|execution|teratorslibrary|iterator|cmath|complex|valarray|random|numeric|ratio|cfenv|iosfwd|ios|istream|ostream|iostream|fstream|sstream|strstream|iomanip|streambuf|cstdio|locale|clocale|codecvt|regex|atomic|thread|mutex|shared_mutex|future|condition_variable|filesystem|ciso646|ccomplex|ctgmath|cstdalign|cstdbool)(>|")$'
+    Priority: 3
+  - Regex: '^(<|").*(>|")$'
+    Priority: 1
+IndentWidth: 4
+InsertNewlineAtEOF: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+QualifierAlignment: Left
+CommentPragmas: '^.*A2Lfactory:'
+---
+# Make sure language specific settings are below the generic settings to be compatible to all languages.
+Language: Cpp
+Standard: c++17

--- a/src/cpp/src/internal/error.cpp
+++ b/src/cpp/src/internal/error.cpp
@@ -15,11 +15,9 @@
 namespace score::mw::per::kvs {
 
 /*********************** Error Implementation *********************/
-std::string_view MyErrorDomain::MessageFor(score::result::ErrorCode const& code) const noexcept
-{
+std::string_view MyErrorDomain::MessageFor(score::result::ErrorCode const& code) const noexcept {
     std::string_view msg;
-    switch (static_cast<ErrorCode>(code))
-    {
+    switch (static_cast<ErrorCode>(code)) {
         case ErrorCode::UnmappedError:
             msg = "Error that was not yet mapped";
             break;
@@ -91,8 +89,7 @@ std::string_view MyErrorDomain::MessageFor(score::result::ErrorCode const& code)
     return msg;
 }
 
-score::result::Error MakeError(ErrorCode code, std::string_view user_message) noexcept
-{
+score::result::Error MakeError(ErrorCode code, std::string_view user_message) noexcept {
     return {static_cast<score::result::ErrorCode>(code), my_error_domain, user_message};
 }
 

--- a/src/cpp/src/internal/error.hpp
+++ b/src/cpp/src/internal/error.hpp
@@ -83,9 +83,8 @@ enum class ErrorCode : score::result::ErrorCode {
     InvalidValueType,
 };
 
-class MyErrorDomain final : public score::result::ErrorDomain
-{
-public:
+class MyErrorDomain final : public score::result::ErrorDomain {
+   public:
     std::string_view MessageFor(score::result::ErrorCode const& code) const noexcept override;
 };
 

--- a/src/cpp/src/internal/kvs_helper.cpp
+++ b/src/cpp/src/internal/kvs_helper.cpp
@@ -39,49 +39,41 @@ uint32_t calculate_hash_adler32(const std::string& data) {
 }
 
 /*Parse Adler32 checksum Byte-Array to uint32 */
-uint32_t parse_hash_adler32(std::istream& in)
-{
-    std::array<uint8_t,4> buf{};
+uint32_t parse_hash_adler32(std::istream& in) {
+    std::array<uint8_t, 4> buf{};
     in.read(reinterpret_cast<char*>(buf.data()), buf.size());
 
-    uint32_t value = (uint32_t(buf[0]) << 24)
-                   | (uint32_t(buf[1]) << 16)
-                   | (uint32_t(buf[2]) <<  8)
-                   |  uint32_t(buf[3]);
+    uint32_t value = (uint32_t(buf[0]) << 24) | (uint32_t(buf[1]) << 16) | (uint32_t(buf[2]) << 8) |
+                     uint32_t(buf[3]);
     return value;
 }
 
 /* Split uint32 checksum in bytes for writing*/
-std::array<uint8_t,4> get_hash_bytes_adler32(uint32_t hash)
-{
-    std::array<uint8_t, 4> value = {
-        uint8_t((hash >> 24) & 0xFF),
-        uint8_t((hash >> 16) & 0xFF),
-        uint8_t((hash >>  8) & 0xFF),
-        uint8_t((hash      ) & 0xFF)
-    };
+std::array<uint8_t, 4> get_hash_bytes_adler32(uint32_t hash) {
+    std::array<uint8_t, 4> value = {uint8_t((hash >> 24) & 0xFF), uint8_t((hash >> 16) & 0xFF),
+                                    uint8_t((hash >> 8) & 0xFF), uint8_t((hash) & 0xFF)};
     return value;
 }
 
 /***** Wrapper Functions for Hash *****/
-/* Wrapper Functions should isolate the Hash Algorithm, so that the algorithm can be easier replaced*/
+/* Wrapper Functions should isolate the Hash Algorithm, so that the algorithm can be easier
+ * replaced*/
 
 /* Wrapper Function to get checksum in bytes*/
-std::array<uint8_t,4> get_hash_bytes(const std::string& data)
-{
+std::array<uint8_t, 4> get_hash_bytes(const std::string& data) {
     uint32_t hash = calculate_hash_adler32(data);
     std::array<uint8_t, 4> value = get_hash_bytes_adler32(hash);
     return value;
 }
 
 /* Wrapper Function to check, if Hash is valid*/
-bool check_hash(const std::string& data_calculate, std::istream& data_parse){
+bool check_hash(const std::string& data_calculate, std::istream& data_parse) {
     bool result;
     uint32_t calculated_hash = calculate_hash_adler32(data_calculate);
     uint32_t parsed_hash = parse_hash_adler32(data_parse);
-    if(calculated_hash == parsed_hash){
+    if (calculated_hash == parsed_hash) {
         result = true;
-    }else{
+    } else {
         result = false;
     }
 
@@ -91,11 +83,11 @@ bool check_hash(const std::string& data_calculate, std::istream& data_parse){
 /*********************** Standalone Helper Functions *********************/
 
 /* Helper Function for Any -> KVSValue conversion */
-score::Result<KvsValue> any_to_kvsvalue(const score::json::Any& any){
+score::Result<KvsValue> any_to_kvsvalue(const score::json::Any& any) {
     score::Result<KvsValue> result = score::MakeUnexpected(ErrorCode::UnmappedError);
     if (auto o = any.As<score::json::Object>(); o.has_value()) {
         const auto& objAny = o.value().get();
-        auto type  = objAny.find("t");
+        auto type = objAny.find("t");
         auto value = objAny.find("v");
         if (type != objAny.end() && value != objAny.end()) {
             if (auto typeStr = type->second.As<std::string>(); typeStr.has_value()) {
@@ -103,70 +95,54 @@ score::Result<KvsValue> any_to_kvsvalue(const score::json::Any& any){
                 const score::json::Any& valueAny = value->second;
 
                 if (typeStrV == "i32") {
-                    if (auto n = valueAny.As<int32_t>(); n.has_value()){
+                    if (auto n = valueAny.As<int32_t>(); n.has_value()) {
                         result = KvsValue(static_cast<int32_t>(n.value()));
-                    }
-                    else {
+                    } else {
                         result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                     }
-                }
-                else if (typeStrV == "u32") {
+                } else if (typeStrV == "u32") {
                     if (auto n = valueAny.As<uint32_t>(); n.has_value()) {
                         result = KvsValue(static_cast<uint32_t>(n.value()));
-                    }
-                    else {
+                    } else {
                         result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                     }
-                }
-                else if (typeStrV == "i64") {
+                } else if (typeStrV == "i64") {
                     if (auto n = valueAny.As<int64_t>(); n.has_value()) {
                         result = KvsValue(static_cast<int64_t>(n.value()));
-                    }
-                    else {
+                    } else {
                         result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                     }
-                }
-                else if (typeStrV == "u64") {
+                } else if (typeStrV == "u64") {
                     if (auto n = valueAny.As<uint64_t>(); n.has_value()) {
                         result = KvsValue(static_cast<uint64_t>(n.value()));
-                    }
-                    else {
+                    } else {
                         result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                     }
-                }
-                else if (typeStrV == "f64") {
+                } else if (typeStrV == "f64") {
                     if (auto n = valueAny.As<double>(); n.has_value()) {
                         result = KvsValue(n.value());
-                    }
-                    else {
+                    } else {
                         result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                     }
-                }
-                else if (typeStrV == "bool") {
+                } else if (typeStrV == "bool") {
                     if (auto b = valueAny.As<bool>(); b.has_value()) {
                         result = KvsValue(b.value());
-                    }
-                    else {
+                    } else {
                         result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                     }
-                }
-                else if (typeStrV == "str") {
+                } else if (typeStrV == "str") {
                     if (auto s = valueAny.As<std::string>(); s.has_value()) {
                         result = KvsValue(s.value().get());
-                    }
-                    else {
+                    } else {
                         result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                     }
-                }
-                else if (typeStrV == "null") {
+                } else if (typeStrV == "null") {
                     if (valueAny.As<score::json::Null>().has_value()) {
                         result = KvsValue(nullptr);
-                    }
-                    else {
+                    } else {
                         result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                     }
-                }
-                else if (typeStrV == "arr") {
+                } else if (typeStrV == "arr") {
                     if (auto l = valueAny.As<score::json::List>(); l.has_value()) {
                         KvsValue::Array arr;
                         bool error = false;
@@ -179,14 +155,13 @@ score::Result<KvsValue> any_to_kvsvalue(const score::json::Any& any){
                             }
                             arr.emplace_back(std::make_shared<KvsValue>(std::move(conv.value())));
                         }
-                        if (!error){
+                        if (!error) {
                             result = KvsValue(std::move(arr));
                         }
                     } else {
                         result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                     }
-                }
-                else if (typeStrV == "obj") {
+                } else if (typeStrV == "obj") {
                     if (auto obj = valueAny.As<score::json::Object>(); obj.has_value()) {
                         KvsValue::Object map;
                         bool error = false;
@@ -197,7 +172,8 @@ score::Result<KvsValue> any_to_kvsvalue(const score::json::Any& any){
                                 result = score::MakeUnexpected(ErrorCode::InvalidValueType);
                                 break;
                             }
-                            map.emplace(key.GetAsStringView().to_string(), std::make_shared<KvsValue>(std::move(conv.value())));
+                            map.emplace(key.GetAsStringView().to_string(),
+                                        std::make_shared<KvsValue>(std::move(conv.value())));
                         }
                         if (!error) {
                             result = KvsValue(std::move(map));
@@ -229,22 +205,26 @@ score::Result<score::json::Any> kvsvalue_to_any(const KvsValue& kv) {
     switch (kv.getType()) {
         case KvsValue::Type::i32: {
             obj.emplace("t", score::json::Any(std::string("i32")));
-            obj.emplace("v", score::json::Any(static_cast<int32_t>(std::get<int32_t>(kv.getValue()))));
+            obj.emplace("v",
+                        score::json::Any(static_cast<int32_t>(std::get<int32_t>(kv.getValue()))));
             break;
         }
         case KvsValue::Type::u32: {
             obj.emplace("t", score::json::Any(std::string("u32")));
-            obj.emplace("v", score::json::Any(static_cast<uint32_t>(std::get<uint32_t>(kv.getValue()))));
+            obj.emplace("v",
+                        score::json::Any(static_cast<uint32_t>(std::get<uint32_t>(kv.getValue()))));
             break;
         }
         case KvsValue::Type::i64: {
             obj.emplace("t", score::json::Any(std::string("i64")));
-            obj.emplace("v", score::json::Any(static_cast<int64_t>(std::get<int64_t>(kv.getValue()))));
+            obj.emplace("v",
+                        score::json::Any(static_cast<int64_t>(std::get<int64_t>(kv.getValue()))));
             break;
         }
         case KvsValue::Type::u64: {
             obj.emplace("t", score::json::Any(std::string("u64")));
-            obj.emplace("v", score::json::Any(static_cast<uint64_t>(std::get<uint64_t>(kv.getValue()))));
+            obj.emplace("v",
+                        score::json::Any(static_cast<uint64_t>(std::get<uint64_t>(kv.getValue()))));
             break;
         }
         case KvsValue::Type::f64: {
@@ -314,6 +294,5 @@ score::Result<score::json::Any> kvsvalue_to_any(const KvsValue& kv) {
 
     return result;
 }
-
 
 } /* namespace score::mw::per::kvs */

--- a/src/cpp/src/internal/kvs_helper.hpp
+++ b/src/cpp/src/internal/kvs_helper.hpp
@@ -27,12 +27,12 @@ namespace score::mw::per::kvs {
 
 uint32_t parse_hash_adler32(std::istream& in);
 uint32_t calculate_hash_adler32(const std::string& data);
-std::array<uint8_t,4> get_hash_bytes_adler32(uint32_t hash);
-std::array<uint8_t,4> get_hash_bytes(const std::string& data);
+std::array<uint8_t, 4> get_hash_bytes_adler32(uint32_t hash);
+std::array<uint8_t, 4> get_hash_bytes(const std::string& data);
 bool check_hash(const std::string& data_calculate, std::istream& data_parse);
 score::Result<KvsValue> any_to_kvsvalue(const score::json::Any& any);
 score::Result<score::json::Any> kvsvalue_to_any(const KvsValue& kv);
 
 } /* namespace score::mw::per::kvs */
 
-#endif // SCORE_LIB_KVS_INTERNAL_KVS_HELPER_HPP
+#endif  // SCORE_LIB_KVS_INTERNAL_KVS_HELPER_HPP

--- a/src/cpp/src/kvs.cpp
+++ b/src/cpp/src/kvs.cpp
@@ -10,16 +10,17 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
+#include "kvs.hpp"
 #include <fstream>
 #include <iostream>
 #include <sstream>
 #include "internal/kvs_helper.hpp"
-#include "kvs.hpp"
 
-//TODO Default Value Handling TBD
-//TODO Add Score Logging
-//TODO Replace std libs with baselibs
-//TODO String Handling in set_value TBD: (e.g. set_value("key", "value") is not correct, since KvsValue() expects a string ptr and not a string)
+// TODO Default Value Handling TBD
+// TODO Add Score Logging
+// TODO Replace std libs with baselibs
+// TODO String Handling in set_value TBD: (e.g. set_value("key", "value") is not correct, since
+// KvsValue() expects a string ptr and not a string)
 
 using namespace std;
 
@@ -27,31 +28,31 @@ namespace score::mw::per::kvs {
 
 /*********************** KVS Implementation *********************/
 Kvs::Kvs()
-    : filesystem(std::make_unique<score::filesystem::Filesystem>(score::filesystem::FilesystemFactory{}.CreateInstance())) /* Create Filesystem instance, noexcept call */
-    , parser(std::make_unique<score::json::JsonParser>())
-    , writer(std::make_unique<score::json::JsonWriter>())
-    , logger(std::make_unique<score::mw::log::Logger>("SKVS"))
-{
-}
+    : filesystem(std::make_unique<score::filesystem::Filesystem>(
+          score::filesystem::FilesystemFactory{}
+              .CreateInstance())) /* Create Filesystem instance, noexcept call */
+      ,
+      parser(std::make_unique<score::json::JsonParser>()),
+      writer(std::make_unique<score::json::JsonWriter>()),
+      logger(std::make_unique<score::mw::log::Logger>("SKVS")) {}
 
 Kvs::Kvs(Kvs&& other) noexcept
-    : filename_prefix(std::move(other.filename_prefix))
-    , filesystem(std::move(other.filesystem))
-    , parser(std::move(other.parser)) /* Not absolutely necessary, because a new JSON writer/parser object would also be okay*/
-    , writer(std::move(other.writer))
-    , logger(std::move(other.logger))
-{
+    : filename_prefix(std::move(other.filename_prefix)),
+      filesystem(std::move(other.filesystem)),
+      parser(std::move(other.parser)) /* Not absolutely necessary, because a new JSON writer/parser
+                                         object would also be okay*/
+      ,
+      writer(std::move(other.writer)),
+      logger(std::move(other.logger)) {
     {
         std::lock_guard<std::mutex> lock(other.kvs_mutex);
         kvs = std::move(other.kvs);
     }
 
     default_values = std::move(other.default_values);
-
 }
 
-Kvs& Kvs::operator=(Kvs&& other) noexcept
-{
+Kvs& Kvs::operator=(Kvs&& other) noexcept {
     if (this != &other) {
         {
             std::lock_guard<std::mutex> lock_this(kvs_mutex);
@@ -78,14 +79,15 @@ Kvs& Kvs::operator=(Kvs&& other) noexcept
 }
 
 /* Helper Function to parse JSON data for open_json*/
-score::Result<std::unordered_map<std::string, KvsValue>> Kvs::parse_json_data(const std::string& data) {
-
-    score::Result<unordered_map<std::string, KvsValue>> result = score::MakeUnexpected(ErrorCode::UnmappedError);
+score::Result<std::unordered_map<std::string, KvsValue>> Kvs::parse_json_data(
+    const std::string& data) {
+    score::Result<unordered_map<std::string, KvsValue>> result =
+        score::MakeUnexpected(ErrorCode::UnmappedError);
     auto any_res = parser->FromBuffer(data);
 
     if (!any_res) {
         result = score::MakeUnexpected(ErrorCode::JsonParserError);
-    }else{
+    } else {
         score::json::Any root = std::move(any_res).value();
         std::unordered_map<std::string, KvsValue> result_value;
 
@@ -100,7 +102,7 @@ score::Result<std::unordered_map<std::string, KvsValue>> Kvs::parse_json_data(co
                     result = score::MakeUnexpected(static_cast<ErrorCode>(*conv.error()));
                     error = true;
                     break;
-                }else{
+                } else {
                     result_value.emplace(std::move(key), std::move(conv.value()));
                 }
             }
@@ -116,14 +118,15 @@ score::Result<std::unordered_map<std::string, KvsValue>> Kvs::parse_json_data(co
 }
 
 /* Open and read JSON File */
-score::Result<std::unordered_map<string, KvsValue>> Kvs::open_json(const score::filesystem::Path& prefix, OpenJsonNeedFile need_file)
-{
+score::Result<std::unordered_map<string, KvsValue>> Kvs::open_json(
+    const score::filesystem::Path& prefix, OpenJsonNeedFile need_file) {
     score::filesystem::Path json_file = prefix.Native() + ".json";
     score::filesystem::Path hash_file = prefix.Native() + ".hash";
     std::string data;
-    bool error = false; /* Error flag */
+    bool error = false;   /* Error flag */
     bool new_kvs = false; /* Flag to check if new KVS file is created*/
-    score::Result<std::unordered_map<string, KvsValue>> result = score::MakeUnexpected(ErrorCode::UnmappedError);
+    score::Result<std::unordered_map<string, KvsValue>> result =
+        score::MakeUnexpected(ErrorCode::UnmappedError);
 
     /* Read JSON file */
     ifstream in(json_file.CStr());
@@ -132,45 +135,46 @@ score::Result<std::unordered_map<string, KvsValue>> Kvs::open_json(const score::
             logger->LogError() << "error: file " << json_file << " could not be read";
             error = true;
             result = score::MakeUnexpected(ErrorCode::KvsFileReadError);
-        }else{
+        } else {
             logger->LogInfo() << "file " << json_file << " not found, using empty data";
             new_kvs = true;
-            result = score::Result<std::unordered_map<string,KvsValue>>({});
+            result = score::Result<std::unordered_map<string, KvsValue>>({});
         }
-    }else{
+    } else {
         ostringstream ss;
         ss << in.rdbuf();
         data = ss.str();
     }
 
     /* Verify JSON Hash */
-    if((!error) && (!new_kvs)){
+    if ((!error) && (!new_kvs)) {
         ifstream hin(hash_file.CStr(), ios::binary);
         if (!hin) {
             logger->LogError() << "error: hash file " << hash_file << " could not be read";
             error = true;
             result = score::MakeUnexpected(ErrorCode::KvsHashFileReadError);
 
-        }else{
+        } else {
             bool valid_hash = check_hash(data, hin);
-            if(!valid_hash){
-                logger->LogError() << "error: KVS data corrupted (" << json_file << ", " << hash_file << ")";
+            if (!valid_hash) {
+                logger->LogError()
+                    << "error: KVS data corrupted (" << json_file << ", " << hash_file << ")";
                 error = true;
                 result = score::MakeUnexpected(ErrorCode::ValidationFailed);
-            }else{
+            } else {
                 logger->LogInfo() << "JSON data has valid hash";
             }
         }
     }
 
     /* Parse JSON Data */
-    if((!error) && (!new_kvs)){
+    if ((!error) && (!new_kvs)) {
         auto parse_res = parse_json_data(data);
         if (!parse_res) {
             logger->LogError() << "error: parsing JSON data failed";
             error = true;
             result = score::MakeUnexpected(static_cast<ErrorCode>(*parse_res.error()));
-        }else{
+        } else {
             result = std::move(parse_res.value());
         }
     }
@@ -179,9 +183,11 @@ score::Result<std::unordered_map<string, KvsValue>> Kvs::open_json(const score::
 }
 
 /* Open KVS Instance */
-score::Result<Kvs> Kvs::open(const InstanceId& instance_id, OpenNeedDefaults need_defaults, OpenNeedKvs need_kvs, const std::string&& dir)
-{
-    score::Result<Kvs> result = score::MakeUnexpected(ErrorCode::UnmappedError); /* Redundant initialization needed, since Resul<KVS> would call the implicitly-deleted default constructor of KVS */
+score::Result<Kvs> Kvs::open(const InstanceId& instance_id, OpenNeedDefaults need_defaults,
+                             OpenNeedKvs need_kvs, const std::string&& dir) {
+    score::Result<Kvs> result = score::MakeUnexpected(
+        ErrorCode::UnmappedError); /* Redundant initialization needed, since Resul<KVS> would call
+                                      the implicitly-deleted default constructor of KVS */
 
     score::filesystem::Path base_path(dir);
     score::filesystem::Path filename_prefix = base_path / ("kvs_" + std::to_string(instance_id.id));
@@ -189,19 +195,20 @@ score::Result<Kvs> Kvs::open(const InstanceId& instance_id, OpenNeedDefaults nee
     const score::filesystem::Path filename_kvs = filename_prefix.Native() + "_0";
 
     Kvs kvs; /* Create KVS instance */
-    auto default_res = kvs.open_json(
-        filename_default,
-        need_defaults == OpenNeedDefaults::Required ? OpenJsonNeedFile::Required : OpenJsonNeedFile::Optional);
-    if (!default_res){
-        result = score::MakeUnexpected(static_cast<ErrorCode>(*default_res.error())); /* Dereferences the Error class to its underlying code -> error.h*/
-    }
-    else{
-        auto kvs_res = kvs.open_json(
-            filename_kvs,
-            need_kvs == OpenNeedKvs::Required ? OpenJsonNeedFile::Required : OpenJsonNeedFile::Optional);
-        if (!kvs_res){
+    auto default_res = kvs.open_json(filename_default, need_defaults == OpenNeedDefaults::Required
+                                                           ? OpenJsonNeedFile::Required
+                                                           : OpenJsonNeedFile::Optional);
+    if (!default_res) {
+        result = score::MakeUnexpected(static_cast<ErrorCode>(
+            *default_res
+                 .error())); /* Dereferences the Error class to its underlying code -> error.h*/
+    } else {
+        auto kvs_res = kvs.open_json(filename_kvs, need_kvs == OpenNeedKvs::Required
+                                                       ? OpenJsonNeedFile::Required
+                                                       : OpenJsonNeedFile::Optional);
+        if (!kvs_res) {
             result = score::MakeUnexpected(static_cast<ErrorCode>(*kvs_res.error()));
-        }else{
+        } else {
             kvs.kvs = std::move(kvs_res.value());
             kvs.default_values = std::move(default_res.value());
             kvs.filename_prefix = filename_prefix;
@@ -221,7 +228,7 @@ score::ResultBlank Kvs::reset() {
     if (lock.owns_lock()) {
         kvs.clear();
         result = score::ResultBlank{};
-    }else{
+    } else {
         result = score::MakeUnexpected(ErrorCode::MutexLockFailed);
     }
 
@@ -230,7 +237,8 @@ score::ResultBlank Kvs::reset() {
 
 /* Retrieve all keys in the KVS*/
 score::Result<std::vector<std::string>> Kvs::get_all_keys() {
-    score::Result<std::vector<std::string>> result = score::MakeUnexpected(ErrorCode::UnmappedError);
+    score::Result<std::vector<std::string>> result =
+        score::MakeUnexpected(ErrorCode::UnmappedError);
     std::unique_lock<std::mutex> lock(kvs_mutex, std::try_to_lock);
     if (lock.owns_lock()) {
         std::vector<std::string> keys;
@@ -239,7 +247,7 @@ score::Result<std::vector<std::string>> Kvs::get_all_keys() {
             keys.emplace_back(key);
         }
         result = std::move(keys);
-    }else{
+    } else {
         result = score::MakeUnexpected(ErrorCode::MutexLockFailed);
     }
 
@@ -251,13 +259,15 @@ score::Result<bool> Kvs::key_exists(const std::string_view key) {
     score::Result<bool> result = score::MakeUnexpected(ErrorCode::UnmappedError);
     std::unique_lock<std::mutex> lock(kvs_mutex, std::try_to_lock);
     if (lock.owns_lock()) {
-        auto search = kvs.find(std::string(key)); /* unordered_map find() needs string and doesnt work with string_view, workaround for c++20: heterogeneous lookup (applies to more functions) */
+        auto search = kvs.find(std::string(
+            key)); /* unordered_map find() needs string and doesnt work with string_view, workaround
+                      for c++20: heterogeneous lookup (applies to more functions) */
         if (search != kvs.end()) {
             result = true;
         } else {
             result = false;
         }
-    }else{
+    } else {
         result = score::MakeUnexpected(ErrorCode::MutexLockFailed);
     }
 
@@ -268,7 +278,7 @@ score::Result<bool> Kvs::key_exists(const std::string_view key) {
 score::Result<KvsValue> Kvs::get_value(const std::string_view key) {
     score::Result<KvsValue> result = score::MakeUnexpected(ErrorCode::UnmappedError);
     std::unique_lock<std::mutex> lock_kvs(kvs_mutex, std::try_to_lock);
-    if (lock_kvs.owns_lock()){
+    if (lock_kvs.owns_lock()) {
         auto search_kvs = kvs.find(std::string(key));
         if (search_kvs != kvs.end()) {
             result = search_kvs->second;
@@ -280,8 +290,7 @@ score::Result<KvsValue> Kvs::get_value(const std::string_view key) {
                 result = score::MakeUnexpected(ErrorCode::KeyNotFound);
             }
         }
-    }
-    else{
+    } else {
         result = score::MakeUnexpected(ErrorCode::MutexLockFailed);
     }
 
@@ -303,24 +312,22 @@ score::Result<KvsValue> Kvs::get_default_value(const std::string_view key) {
 }
 
 /* Resets a Key to its default value (Deletes written key if default is available) */
-score::ResultBlank Kvs::reset_key(const std::string_view key)
-{
+score::ResultBlank Kvs::reset_key(const std::string_view key) {
     score::ResultBlank result = score::MakeUnexpected(ErrorCode::UnmappedError);
     std::unique_lock<std::mutex> lock_kvs(kvs_mutex, std::try_to_lock);
     if (!lock_kvs.owns_lock()) {
         result = score::MakeUnexpected(ErrorCode::MutexLockFailed);
-    }
-    else {
+    } else {
         auto search_default = default_values.find(std::string(key));
         if (search_default == default_values.end()) {
             result = score::MakeUnexpected(ErrorCode::KeyDefaultNotFound);
-        }
-        else {
+        } else {
             auto search_kvs = kvs.find(std::string(key));
             if (search_kvs != kvs.end()) {
-                (void)kvs.erase(std::string(key)); /* Return Value ignored, since its already secured, that the key exists*/
+                (void)kvs.erase(std::string(
+                    key)); /* Return Value ignored, since its already secured, that the key exists*/
                 result = score::ResultBlank{};
-            }else{
+            } else {
                 result = score::ResultBlank{};
             }
         }
@@ -333,7 +340,9 @@ score::ResultBlank Kvs::reset_key(const std::string_view key)
 score::Result<bool> Kvs::has_default_value(const std::string_view key) {
     score::Result<bool> result = score::MakeUnexpected(ErrorCode::UnmappedError);
 
-    auto search = default_values.find(std::string(key)); /* unordered_map find() needs string and doesnt work with string_view, workaround for c++20: heterogeneous lookup (applies to more functions) */
+    auto search = default_values.find(std::string(
+        key)); /* unordered_map find() needs string and doesnt work with string_view, workaround for
+                  c++20: heterogeneous lookup (applies to more functions) */
     if (search != default_values.end()) {
         result = true;
     } else {
@@ -350,7 +359,7 @@ score::ResultBlank Kvs::set_value(const std::string_view key, const KvsValue& va
     if (lock.owns_lock()) {
         kvs.insert_or_assign(std::string(key), value);
         result = score::ResultBlank{};
-    }else{
+    } else {
         result = score::MakeUnexpected(ErrorCode::MutexLockFailed);
     }
 
@@ -368,7 +377,7 @@ score::ResultBlank Kvs::remove_key(const std::string_view key) {
         } else {
             result = score::MakeUnexpected(ErrorCode::KeyNotFound);
         }
-    }else{
+    } else {
         result = score::MakeUnexpected(ErrorCode::MutexLockFailed);
     }
 
@@ -376,14 +385,13 @@ score::ResultBlank Kvs::remove_key(const std::string_view key) {
 }
 
 /* Helper Function to write JSON data to a file for flush process (also adds Hash file)*/
-score::ResultBlank Kvs::write_json_data(const std::string& buf)
-{
+score::ResultBlank Kvs::write_json_data(const std::string& buf) {
     score::ResultBlank result = score::MakeUnexpected(ErrorCode::UnmappedError);
     score::filesystem::Path json_path{filename_prefix.Native() + "_0.json"};
     score::filesystem::Path dir = json_path.ParentPath();
-    if  (!dir.Empty()) {
+    if (!dir.Empty()) {
         const auto create_path_res = filesystem->standard->CreateDirectories(dir);
-        if(!create_path_res.has_value()) {
+        if (!create_path_res.has_value()) {
             result = score::MakeUnexpected(ErrorCode::PhysicalStorageFailure);
         } else {
             std::ofstream out(json_path.CStr(), std::ios::binary);
@@ -394,7 +402,8 @@ score::ResultBlank Kvs::write_json_data(const std::string& buf)
                 std::array<uint8_t, 4> hash_bytes = get_hash_bytes(buf);
                 score::filesystem::Path fn_hash = filename_prefix.Native() + "_0.hash";
                 std::ofstream hout(fn_hash.CStr(), std::ios::binary);
-                if (!hout.write(reinterpret_cast<const char*>(hash_bytes.data()), hash_bytes.size())) {
+                if (!hout.write(reinterpret_cast<const char*>(hash_bytes.data()),
+                                hash_bytes.size())) {
                     result = score::MakeUnexpected(ErrorCode::PhysicalStorageFailure);
                 } else {
                     result = score::ResultBlank{};
@@ -424,10 +433,9 @@ score::ResultBlank Kvs::flush() {
                     result = score::MakeUnexpected(static_cast<ErrorCode>(*conv.error()));
                     error = true;
                     break;
-                }else{
+                } else {
                     root_obj.emplace(
-                        key,
-                        std::move(conv.value()) /*emplace in map uses move operator*/
+                        key, std::move(conv.value()) /*emplace in map uses move operator*/
                     );
                 }
             }
@@ -437,17 +445,17 @@ score::ResultBlank Kvs::flush() {
         }
     }
 
-    if(!error){
+    if (!error) {
         /* Serialize Buffer */
         auto buf_res = writer->ToBuffer(root_obj);
         if (!buf_res) {
             result = score::MakeUnexpected(ErrorCode::JsonGeneratorError);
-        }else{
+        } else {
             /* Rotate Snapshots */
             auto rotate_result = snapshot_rotate();
             if (!rotate_result) {
                 result = rotate_result;
-            }else{
+            } else {
                 /* Write JSON Data */
                 std::string buf = std::move(buf_res.value());
                 result = write_json_data(buf);
@@ -464,13 +472,14 @@ score::Result<size_t> Kvs::snapshot_count() const {
     size_t count = 0;
     bool error = false;
     for (size_t idx = 1; idx <= KVS_MAX_SNAPSHOTS; ++idx) {
-        const score::filesystem::Path fname = filename_prefix.Native() + "_" + to_string(idx) + ".json";
+        const score::filesystem::Path fname =
+            filename_prefix.Native() + "_" + to_string(idx) + ".json";
         const auto fname_exists_res = filesystem->standard->Exists(fname);
         if (fname_exists_res) {
-            if(false == fname_exists_res.value()) {
+            if (false == fname_exists_res.value()) {
                 break;
             }
-        } else{
+        } else {
             error = true;
             break;
         }
@@ -486,9 +495,7 @@ score::Result<size_t> Kvs::snapshot_count() const {
 }
 
 /* Retrieve the max snapshot count*/
-size_t Kvs::snapshot_max_count() const {
-    return KVS_MAX_SNAPSHOTS;
-}
+size_t Kvs::snapshot_max_count() const { return KVS_MAX_SNAPSHOTS; }
 
 /* Rotate Snapshots */
 score::ResultBlank Kvs::snapshot_rotate() {
@@ -497,10 +504,14 @@ score::ResultBlank Kvs::snapshot_rotate() {
     if (lock.owns_lock()) {
         bool error = false;
         for (size_t idx = KVS_MAX_SNAPSHOTS; idx > 0; --idx) {
-            score::filesystem::Path hash_old = filename_prefix.Native() + "_" + to_string(idx - 1) + ".hash";
-            score::filesystem::Path hash_new = filename_prefix.Native() + "_" + to_string(idx)     + ".hash";
-            score::filesystem::Path snap_old = filename_prefix.Native() + "_" + to_string(idx - 1) + ".json";
-            score::filesystem::Path snap_new = filename_prefix.Native() + "_" + to_string(idx)     + ".json";
+            score::filesystem::Path hash_old =
+                filename_prefix.Native() + "_" + to_string(idx - 1) + ".hash";
+            score::filesystem::Path hash_new =
+                filename_prefix.Native() + "_" + to_string(idx) + ".hash";
+            score::filesystem::Path snap_old =
+                filename_prefix.Native() + "_" + to_string(idx - 1) + ".json";
+            score::filesystem::Path snap_new =
+                filename_prefix.Native() + "_" + to_string(idx) + ".json";
 
             logger->LogInfo() << "rotating: " << snap_old << " -> " << snap_new;
             /* Rename hash */
@@ -508,26 +519,28 @@ score::ResultBlank Kvs::snapshot_rotate() {
             if (0 != hash_rename) {
                 if (errno != ENOENT) {
                     error = true;
-                    logger->LogError() << "error: could not rename hash file " << snap_old << ". Rename Errorcode " << errno;
+                    logger->LogError() << "error: could not rename hash file " << snap_old
+                                       << ". Rename Errorcode " << errno;
                     result = score::MakeUnexpected(ErrorCode::PhysicalStorageFailure);
                 }
             }
-            if(!error){
+            if (!error) {
                 /* Rename snapshot */
                 int32_t snap_rename = std::rename(snap_old.CStr(), snap_new.CStr());
                 if (0 != snap_rename) {
                     if (errno != ENOENT) {
                         error = true;
-                        logger->LogError() << "error: could not rename snapshot file " << snap_old << ". Rename Errorcode " << errno;
+                        logger->LogError() << "error: could not rename snapshot file " << snap_old
+                                           << ". Rename Errorcode " << errno;
                         result = score::MakeUnexpected(ErrorCode::PhysicalStorageFailure);
                     }
                 }
             }
-            if(error){
+            if (error) {
                 break;
             }
         }
-        if(!error){
+        if (!error) {
             result = score::ResultBlank{};
         }
     } else {
@@ -545,20 +558,19 @@ score::ResultBlank Kvs::snapshot_restore(const SnapshotId& snapshot_id) {
         auto snapshot_count_res = snapshot_count();
         if (!snapshot_count_res) {
             result = score::MakeUnexpected(static_cast<ErrorCode>(*snapshot_count_res.error()));
-        }else{
+        } else {
             /* Fail if the snapshot ID is the current KVS */
             if (0 == snapshot_id.id) {
                 result = score::MakeUnexpected(ErrorCode::InvalidSnapshotId);
-            }else if (snapshot_count_res.value() < snapshot_id.id) {
+            } else if (snapshot_count_res.value() < snapshot_id.id) {
                 result = score::MakeUnexpected(ErrorCode::InvalidSnapshotId);
-            }else{
-                score::filesystem::Path restore_path = filename_prefix.Native() + "_" + to_string(snapshot_id.id);
-                auto data_res = open_json(
-                    restore_path,
-                    OpenJsonNeedFile::Required);
+            } else {
+                score::filesystem::Path restore_path =
+                    filename_prefix.Native() + "_" + to_string(snapshot_id.id);
+                auto data_res = open_json(restore_path, OpenJsonNeedFile::Required);
                 if (!data_res) {
                     result = score::MakeUnexpected(static_cast<ErrorCode>(*data_res.error()));
-                }else{
+                } else {
                     kvs = std::move(data_res.value());
                     result = score::ResultBlank{};
                 }
@@ -573,7 +585,8 @@ score::ResultBlank Kvs::snapshot_restore(const SnapshotId& snapshot_id) {
 
 /* Get the filename for a snapshot*/
 score::Result<score::filesystem::Path> Kvs::get_kvs_filename(const SnapshotId& snapshot_id) const {
-    score::filesystem::Path filename = filename_prefix.Native() + "_" + std::to_string(snapshot_id.id) + ".json";
+    score::filesystem::Path filename =
+        filename_prefix.Native() + "_" + std::to_string(snapshot_id.id) + ".json";
     score::Result<score::filesystem::Path> result = score::MakeUnexpected(ErrorCode::UnmappedError);
 
     const auto fname_exists_res = filesystem->standard->Exists(filename);
@@ -591,7 +604,8 @@ score::Result<score::filesystem::Path> Kvs::get_kvs_filename(const SnapshotId& s
 
 /* Get the hash filename for a snapshot*/
 score::Result<score::filesystem::Path> Kvs::get_hash_filename(const SnapshotId& snapshot_id) const {
-    score::filesystem::Path filename = filename_prefix.Native() + "_" + std::to_string(snapshot_id.id) + ".hash";
+    score::filesystem::Path filename =
+        filename_prefix.Native() + "_" + std::to_string(snapshot_id.id) + ".hash";
     score::Result<score::filesystem::Path> result = score::MakeUnexpected(ErrorCode::UnmappedError);
 
     const auto fname_exists_res = filesystem->standard->Exists(filename);

--- a/src/cpp/src/kvs.hpp
+++ b/src/cpp/src/kvs.hpp
@@ -25,8 +25,8 @@
 #include "score/filesystem/filesystem.h"
 #include "score/json/json_parser.h"
 #include "score/json/json_writer.h"
-#include "score/result/result.h"
 #include "score/mw/log/logger.h"
+#include "score/result/result.h"
 
 #define KVS_MAX_SNAPSHOTS 3
 
@@ -36,7 +36,8 @@ struct InstanceId {
     size_t id;
 
     /* Constructor to initialize 'id' */
-    /* Not explicit to allow implicit construction e.g. function(0) instead function(InstanceId(0)) */
+    /* Not explicit to allow implicit construction e.g. function(0) instead function(InstanceId(0))
+     */
     InstanceId(size_t id) { this->id = id; }
 };
 
@@ -44,26 +45,27 @@ struct SnapshotId {
     size_t id;
 
     /* Constructor to initialize 'id'*/
-    /* Not explicit to allow implicit construction e.g. function(0) instead function(SnapshotId(0)) */
+    /* Not explicit to allow implicit construction e.g. function(0) instead function(SnapshotId(0))
+     */
     SnapshotId(size_t id) { this->id = id; }
 };
 
 /* Need-Defaults flag*/
-enum class OpenNeedDefaults{
+enum class OpenNeedDefaults {
     Optional = 0, /* Optional: Use an empty defaults Storage if not available*/
-    Required = 1 /* Required: Defaults must be available*/
+    Required = 1  /* Required: Defaults must be available*/
 };
 
 /* Need-KVS flag*/
 enum class OpenNeedKvs {
     Optional = 0, /* Optional: Use an empty KVS if no KVS is available*/
-    Required = 1 /* Required: KVS must be already exist*/
+    Required = 1  /* Required: KVS must be already exist*/
 };
 
 /* Need-File flag */
 enum class OpenJsonNeedFile {
     Optional = 0, /* Optional: If the file doesn't exist, start with empty data */
-    Required = 1 /* Required: The file must already exist */
+    Required = 1  /* Required: The file must already exist */
 };
 
 /**
@@ -80,7 +82,8 @@ enum class OpenJsonNeedFile {
  * - `reset`: Resets the KVS to its initial state.
  * - `get_all_keys`: Retrieves all keys stored in the KVS (only written keys, not defaults).
  * - `key_exists`: Checks if a specific key exists in the KVS (only written keys).
- * - `get_value`: Retrieves the value associated with a specific key (returns default if not written).
+ * - `get_value`: Retrieves the value associated with a specific key (returns default if not
+ * written).
  * - `get_default_value`: Retrieves the default value associated with a specific key.
  * - `reset_key`: Resets a key to its default value if available.
  * - `has_default_value`: Checks if a default value exists for a specific key.
@@ -115,263 +118,256 @@ enum class OpenJsonNeedFile {
  * Refer: "Blank and score::ResultBlank shall be used for `T` instead of `void`" in result.h
  * A KVS Object is not copyable, but it can be moved.
  *
-*/
+ */
 
 class Kvs final {
-    public:
+   public:
+    // Deleted copy constructor and assignment operator to prevent copying
+    Kvs(const Kvs&) = delete;
+    Kvs& operator=(const Kvs&) = delete;
 
-        // Deleted copy constructor and assignment operator to prevent copying
-        Kvs(const Kvs&) = delete;
-        Kvs& operator=(const Kvs&) = delete;
+    // Default move constructor and assignment operator
+    Kvs(Kvs&& other) noexcept;
+    Kvs& operator=(Kvs&& other) noexcept;
 
-        // Default move constructor and assignment operator
-        Kvs(Kvs&& other) noexcept;
-        Kvs& operator=(Kvs&& other) noexcept;
+    /**
+     * @brief Opens the key-value store with the specified instance ID and flags.
+     *
+     * This function initializes and opens the key-value store (KVS) for a given instance ID.
+     * It allows the caller to specify whether default values and an existing KVS are required
+     * or optional during the opening process.
+     *
+     * @param id The instance ID of the KVS. This uniquely identifies the KVS instance.
+     * @param need_defaults A flag of type OpenNeedDefaults indicating whether default values
+     *                      are required or optional.
+     *                      - OpenNeedDefaults::Required: Default values must be available.
+     *                      - OpenNeedDefaults::Optional: Default values are optional.
+     * @param need_kvs A flag of type OpenNeedKvs indicating whether the KVS is required or
+     * optional.
+     *                 - OpenNeedKvs::Required: The KVS must already exist.
+     *                 - OpenNeedKvs::Optional: An empty KVS will be used if no KVS exists.
+     * @param dir The directory path where the KVS files are located. It is passed as an rvalue
+     * reference to avoid unnecessary copying. Use "" or "." for the current directory.
+     * @return A Result object containing either:
+     *         - A Kvs object if the operation is successful.
+     *         - An ErrorCode if an error occurs during the operation.
+     *
+     * IMPORTANT: Instead of using the Kvs::open method directly, it is recommended to use the
+     * KvsBuilder class.
+     *
+     */
+    static score::Result<Kvs> open(const InstanceId& instance_id, OpenNeedDefaults need_defaults,
+                                   OpenNeedKvs need_kvs, const std::string&& dir);
 
-        /**
-         * @brief Opens the key-value store with the specified instance ID and flags.
-         *
-         * This function initializes and opens the key-value store (KVS) for a given instance ID.
-         * It allows the caller to specify whether default values and an existing KVS are required
-         * or optional during the opening process.
-         *
-         * @param id The instance ID of the KVS. This uniquely identifies the KVS instance.
-         * @param need_defaults A flag of type OpenNeedDefaults indicating whether default values
-         *                      are required or optional.
-         *                      - OpenNeedDefaults::Required: Default values must be available.
-         *                      - OpenNeedDefaults::Optional: Default values are optional.
-         * @param need_kvs A flag of type OpenNeedKvs indicating whether the KVS is required or optional.
-         *                 - OpenNeedKvs::Required: The KVS must already exist.
-         *                 - OpenNeedKvs::Optional: An empty KVS will be used if no KVS exists.
-         * @param dir The directory path where the KVS files are located. It is passed as an rvalue reference to avoid unnecessary copying.
-         *            Use "" or "." for the current directory.
-         * @return A Result object containing either:
-         *         - A Kvs object if the operation is successful.
-         *         - An ErrorCode if an error occurs during the operation.
-         *
-         * IMPORTANT: Instead of using the Kvs::open method directly, it is recommended to use the KvsBuilder class.
-         *
-         */
-        static score::Result<Kvs> open(const InstanceId& instance_id, OpenNeedDefaults need_defaults, OpenNeedKvs need_kvs, const std::string&& dir);
+    /**
+     * @brief Resets a key-value-storage to its initial state
+     *
+     */
+    score::ResultBlank reset();
 
+    /**
+     * @brief Retrieves all keys stored in the key-value store.
+     *        Important: It only retrieves the written keys, no default keys are returned.
+     *
+     * @return score::Result<std::vector<std::string_view>>
+     *         A score::Result object containing a vector of all written keys on success,
+     *         or an Errorcode on failure.
+     */
+    score::Result<std::vector<std::string>> get_all_keys();
 
-        /**
-         * @brief Resets a key-value-storage to its initial state
-         *
-         */
-        score::ResultBlank reset();
+    /**
+     * @brief Checks if a key exists in the key-value store. If the key was never written it will
+     * always return false even if a default value for the key is available.
+     *
+     * @param key The key to check for existence, provided as a std::string_view.
+     * @return score::Result<bool>
+     *         - On success: A score::Result containing `true` if the key exists, or `false` if it
+     * does not.
+     *         - On failure: A score::Result containing an appropriate ErrorCode.
+     */
+    score::Result<bool> key_exists(const std::string_view key);
 
+    /**
+     * @brief Retrieves the value associated with the specified key from the key-value store.
+     *        If no Key was written, it returns the default value if available.
+     *
+     * @param key The key for which the value is to be retrieved. It is passed as a string view to
+     * avoid unnecessary copying.
+     * @return A score::Result object containing either the retrieved value (KvsValue) or an
+     * ErrorCode if the operation fails.
+     */
+    score::Result<KvsValue> get_value(const std::string_view key);
 
-        /**
-         * @brief Retrieves all keys stored in the key-value store.
-         *        Important: It only retrieves the written keys, no default keys are returned.
-         *
-         * @return score::Result<std::vector<std::string_view>>
-         *         A score::Result object containing a vector of all written keys on success,
-         *         or an Errorcode on failure.
-         */
-        score::Result<std::vector<std::string>> get_all_keys();
+    /**
+     * @brief Retrieves the default value associated with the specified key.
+     *
+     * This function attempts to fetch the default value for a given key from the
+     * key-value store. If the key exists, the corresponding value is returned.
+     * Otherwise, an error code is provided to indicate the failure reason.
+     *
+     * @param key The key for which the default value is to be retrieved.
+     *            It is passed as a string view to avoid unnecessary string copies.
+     *
+     * @return A score::Result object containing either the default value (KvsValue) if
+     *         the operation is successful, or an ErrorCode indicating the error
+     *         if the operation fails.
+     */
+    score::Result<KvsValue> get_default_value(const std::string_view key);
 
+    /**
+     * @brief Resets a specified key to its default value.
+     *
+     * This function attempts to reset a key to its default value.
+     * If no default value is available, it returns an ErrorCode and doesn't delete the key.
+     * If no key was ever written, but a default value is available it returns successful.
+     * If a key was written and it has a default value, it deletes the written key.
+     *
+     * @param key The key to be reset to the default value
+     *
+     * @return A score::Result object that indicates the success or failure of the operation.
+     *         - On success: Returns a blank score::Result.
+     *         - On failure: Returns an ErrorCode describing the error.
+     */
+    score::ResultBlank reset_key(const std::string_view key);
 
-        /**
-         * @brief Checks if a key exists in the key-value store. If the key was never written it will always
-         *        return false even if a default value for the key is available.
-         *
-         * @param key The key to check for existence, provided as a std::string_view.
-         * @return score::Result<bool>
-         *         - On success: A score::Result containing `true` if the key exists, or `false` if it does not.
-         *         - On failure: A score::Result containing an appropriate ErrorCode.
-         */
-        score::Result<bool> key_exists(const std::string_view key);
+    /**
+     * @brief Checks if the specified key has a default value.
+     *
+     * This function determines whether the given key is associated with a default
+     * value in the key-value store.
+     *
+     * @param key The key to check, provided as a string view.
+     * @return score::Result<bool>
+     *         - On success: Returns a score::Result<bool> containing bool if the default value
+     * exists.
+     *         - On failure: Returns a score::Result containing an appropriate ErrorCode.
+     */
+    score::Result<bool> has_default_value(const std::string_view key);
 
+    /**
+     * @brief Stores a key-value pair in the key-value store.
+     *
+     * @param key The key associated with the value to be stored.
+     *            It is represented as a string view to avoid unnecessary copying.
+     * @param value The value to be stored, represented as a KvsValue object.
+     *
+     * @return A score::Result object that indicates the success or failure of the operation.
+     *         - On success: Returns a blank score::Result.
+     *         - On failure: Returns an ErrorCode describing the error.
+     */
+    score::ResultBlank set_value(const std::string_view key, const KvsValue& value);
 
-        /**
-         * @brief Retrieves the value associated with the specified key from the key-value store.
-         *        If no Key was written, it returns the default value if available.
-         *
-         * @param key The key for which the value is to be retrieved. It is passed as a string view to avoid unnecessary copying.
-         * @return A score::Result object containing either the retrieved value (KvsValue) or an ErrorCode
-         *         if the operation fails.
-         */
-        score::Result<KvsValue> get_value(const std::string_view key);
+    /**
+     * @brief Removes a key-value pair from the store based on the specified key.
+     *
+     * @param key The key of the key-value pair to be removed. It is passed as a
+     *            std::string_view to avoid unnecessary copying.
+     * @return A score::Result object that indicates the success or failure of the operation.
+     *         - On success: Returns a blank score::Result.
+     *         - On failure: Returns an ErrorCode describing the error.
+     */
+    score::ResultBlank remove_key(const std::string_view key);
 
+    /**
+     * @brief Flushes the key-value store, ensuring that all pending changes
+     *        are written to the underlying storage.
+     *
+     * @return A score::Result object that indicates the success or failure of the operation.
+     *         - On success: Returns a blank score::Result.
+     *         - On failure: Returns an ErrorCode describing the error.
+     */
+    score::ResultBlank flush();
 
-        /**
-         * @brief Retrieves the default value associated with the specified key.
-         *
-         * This function attempts to fetch the default value for a given key from the
-         * key-value store. If the key exists, the corresponding value is returned.
-         * Otherwise, an error code is provided to indicate the failure reason.
-         *
-         * @param key The key for which the default value is to be retrieved.
-         *            It is passed as a string view to avoid unnecessary string copies.
-         *
-         * @return A score::Result object containing either the default value (KvsValue) if
-         *         the operation is successful, or an ErrorCode indicating the error
-         *         if the operation fails.
-         */
-        score::Result<KvsValue> get_default_value(const std::string_view key);
+    /**
+     * @brief Retrieves the number of snapshots currently stored in the key-value store.
+     *
+     * @return A score::Result object that indicates the success or failure of the operation.
+     *         - On success: The total count of snapshots as a size_t value.
+     *         - On failure: Returns an ErrorCode describing the error.
+     */
+    score::Result<size_t> snapshot_count() const;
 
+    /**
+     * @brief Retrieves the maximum number of snapshots that can be stored.
+     *
+     * This function returns the upper limit on the number of snapshots
+     * that the key-value store can maintain at any given time.
+     *
+     * @return The maximum count of snapshots as a size_t value.
+     */
+    size_t snapshot_max_count() const;
 
-        /**
-         * @brief Resets a specified key to its default value.
-         *
-         * This function attempts to reset a key to its default value.
-         * If no default value is available, it returns an ErrorCode and doesn't delete the key.
-         * If no key was ever written, but a default value is available it returns successful.
-         * If a key was written and it has a default value, it deletes the written key.
-         *
-         * @param key The key to be reset to the default value
-         *
-         * @return A score::Result object that indicates the success or failure of the operation.
-         *         - On success: Returns a blank score::Result.
-         *         - On failure: Returns an ErrorCode describing the error.
-         */
-        score::ResultBlank reset_key(const std::string_view key);
+    /**
+     * @brief Restores the state of the key-value store from a specified snapshot.
+     *
+     * This function attempts to restore the key-value store to the state
+     * captured in the snapshot identified by the given snapshot ID. If the
+     * restoration process fails, an appropriate error code is returned.
+     *
+     * @param snapshot_id The identifier of the snapshot to restore from.
+     * @return score::ResultBlank
+     *         - On success: An empty score::Result indicating the restoration was successful.
+     *         - On failure: An error code describing the reason for the failure.
+     */
+    score::ResultBlank snapshot_restore(const SnapshotId& snapshot_id);
 
+    /**
+     * @brief Retrieves the filename associated with a given snapshot ID in the key-value store.
+     *
+     * @param snapshot_id The identifier of the snapshot for which the filename is to be retrieved.
+     * @return score::ResultBlank
+     *         - On success: A score::filesystem::Path with the filename (path) associated with the
+     * snapshot ID.
+     *         - On failure: An error code describing the reason for the failure.
+     */
+    score::Result<score::filesystem::Path> get_kvs_filename(const SnapshotId& snapshot_id) const;
 
-        /**
-         * @brief Checks if the specified key has a default value.
-         *
-         * This function determines whether the given key is associated with a default
-         * value in the key-value store.
-         *
-         * @param key The key to check, provided as a string view.
-         * @return score::Result<bool>
-         *         - On success: Returns a score::Result<bool> containing bool if the default value exists.
-         *         - On failure: Returns a score::Result containing an appropriate ErrorCode.
-         */
-        score::Result<bool> has_default_value(const std::string_view key);
+    /**
+     * @brief Retrieves the filename of the hash file associated with a given snapshot ID.
+     *
+     * This function returns a string view representing the filename of the hash file
+     * corresponding to the provided snapshot ID. The hash file is typically used to
+     * store metadata or integrity information for the snapshot.
+     *
+     * @param snapshot_id The identifier of the snapshot for which the hash filename is requested.
+     * @return score::ResultBlank
+     *         - On success: A score::filesystem::Path with the filename (path) of the hash file
+     * associated with the snapshot ID.
+     *         - On failure: An error code describing the reason for the failure.
+     */
+    score::Result<score::filesystem::Path> get_hash_filename(const SnapshotId& snapshot_id) const;
 
+   private:
+    /* Private constructor to prevent direct instantiation */
+    Kvs();
 
-        /**
-         * @brief Stores a key-value pair in the key-value store.
-         *
-         * @param key The key associated with the value to be stored.
-         *            It is represented as a string view to avoid unnecessary copying.
-         * @param value The value to be stored, represented as a KvsValue object.
-         *
-         * @return A score::Result object that indicates the success or failure of the operation.
-         *         - On success: Returns a blank score::Result.
-         *         - On failure: Returns an ErrorCode describing the error.
-         */
-        score::ResultBlank set_value(const std::string_view key, const KvsValue& value);
+    /* Internal storage and configuration details.*/
+    std::mutex kvs_mutex;
+    std::unordered_map<std::string, KvsValue> kvs;
 
+    /* Optional default values */
+    std::unordered_map<std::string, KvsValue> default_values;
 
-        /**
-         * @brief Removes a key-value pair from the store based on the specified key.
-         *
-         * @param key The key of the key-value pair to be removed. It is passed as a
-         *            std::string_view to avoid unnecessary copying.
-         * @return A score::Result object that indicates the success or failure of the operation.
-         *         - On success: Returns a blank score::Result.
-         *         - On failure: Returns an ErrorCode describing the error.
-         */
-        score::ResultBlank remove_key(const std::string_view key);
+    /* Filename prefix */
+    score::filesystem::Path filename_prefix;
 
+    /* Filesystem handling */
+    std::unique_ptr<score::filesystem::Filesystem> filesystem;
 
-        /**
-         * @brief Flushes the key-value store, ensuring that all pending changes
-         *        are written to the underlying storage.
-         *
-         * @return A score::Result object that indicates the success or failure of the operation.
-         *         - On success: Returns a blank score::Result.
-         *         - On failure: Returns an ErrorCode describing the error.
-         */
-        score::ResultBlank flush();
+    /* Json handling */
+    std::unique_ptr<score::json::IJsonParser> parser;
+    std::unique_ptr<score::json::IJsonWriter> writer;
 
+    /* Logging */
+    std::unique_ptr<score::mw::log::Logger> logger;
 
-        /**
-         * @brief Retrieves the number of snapshots currently stored in the key-value store.
-         *
-         * @return A score::Result object that indicates the success or failure of the operation.
-         *         - On success: The total count of snapshots as a size_t value.
-         *         - On failure: Returns an ErrorCode describing the error.
-         */
-        score::Result<size_t> snapshot_count() const;
-
-
-        /**
-         * @brief Retrieves the maximum number of snapshots that can be stored.
-         *
-         * This function returns the upper limit on the number of snapshots
-         * that the key-value store can maintain at any given time.
-         *
-         * @return The maximum count of snapshots as a size_t value.
-         */
-        size_t snapshot_max_count() const;
-
-
-        /**
-         * @brief Restores the state of the key-value store from a specified snapshot.
-         *
-         * This function attempts to restore the key-value store to the state
-         * captured in the snapshot identified by the given snapshot ID. If the
-         * restoration process fails, an appropriate error code is returned.
-         *
-         * @param snapshot_id The identifier of the snapshot to restore from.
-         * @return score::ResultBlank
-         *         - On success: An empty score::Result indicating the restoration was successful.
-         *         - On failure: An error code describing the reason for the failure.
-         */
-        score::ResultBlank snapshot_restore(const SnapshotId& snapshot_id);
-
-
-        /**
-         * @brief Retrieves the filename associated with a given snapshot ID in the key-value store.
-         *
-         * @param snapshot_id The identifier of the snapshot for which the filename is to be retrieved.
-         * @return score::ResultBlank
-         *         - On success: A score::filesystem::Path with the filename (path) associated with the snapshot ID.
-         *         - On failure: An error code describing the reason for the failure.
-         */
-        score::Result<score::filesystem::Path> get_kvs_filename(const SnapshotId& snapshot_id) const;
-
-
-        /**
-         * @brief Retrieves the filename of the hash file associated with a given snapshot ID.
-         *
-         * This function returns a string view representing the filename of the hash file
-         * corresponding to the provided snapshot ID. The hash file is typically used to
-         * store metadata or integrity information for the snapshot.
-         *
-         * @param snapshot_id The identifier of the snapshot for which the hash filename is requested.
-         * @return score::ResultBlank
-         *         - On success: A score::filesystem::Path with the filename (path) of the hash file associated with the snapshot ID.
-         *         - On failure: An error code describing the reason for the failure.
-         */
-        score::Result<score::filesystem::Path> get_hash_filename(const SnapshotId& snapshot_id) const;
-
-    private:
-        /* Private constructor to prevent direct instantiation */
-        Kvs();
-
-        /* Internal storage and configuration details.*/
-        std::mutex kvs_mutex;
-        std::unordered_map<std::string, KvsValue> kvs;
-
-        /* Optional default values */
-        std::unordered_map<std::string, KvsValue> default_values;
-
-        /* Filename prefix */
-        score::filesystem::Path filename_prefix;
-
-        /* Filesystem handling */
-        std::unique_ptr<score::filesystem::Filesystem> filesystem;
-
-        /* Json handling */
-        std::unique_ptr<score::json::IJsonParser> parser;
-        std::unique_ptr<score::json::IJsonWriter> writer;
-
-        /* Logging */
-        std::unique_ptr<score::mw::log::Logger> logger;
-
-        /* Private Methods */
-        score::ResultBlank snapshot_rotate();
-        score::Result<std::unordered_map<std::string, KvsValue>> parse_json_data(const std::string& data);
-        score::Result<std::unordered_map<std::string, KvsValue>> open_json(const score::filesystem::Path& prefix, OpenJsonNeedFile need_file);
-        score::ResultBlank write_json_data(const std::string& buf);
-
+    /* Private Methods */
+    score::ResultBlank snapshot_rotate();
+    score::Result<std::unordered_map<std::string, KvsValue>> parse_json_data(
+        const std::string& data);
+    score::Result<std::unordered_map<std::string, KvsValue>> open_json(
+        const score::filesystem::Path& prefix, OpenJsonNeedFile need_file);
+    score::ResultBlank write_json_data(const std::string& buf);
 };
 
 } /* namespace score::mw::per::kvs */

--- a/src/cpp/src/kvsbuilder.cpp
+++ b/src/cpp/src/kvsbuilder.cpp
@@ -16,10 +16,10 @@ namespace score::mw::per::kvs {
 
 /*********************** KVS Builder Implementation *********************/
 KvsBuilder::KvsBuilder(const InstanceId& instance_id)
-    : instance_id(instance_id)
-    , need_defaults(false)
-    , need_kvs(false)
-    , directory("./data_folder/") /* Default Directory */
+    : instance_id(instance_id),
+      need_defaults(false),
+      need_kvs(false),
+      directory("./data_folder/") /* Default Directory */
 {}
 
 KvsBuilder& KvsBuilder::need_defaults_flag(bool flag) {
@@ -37,7 +37,6 @@ KvsBuilder& KvsBuilder::dir(std::string&& dir_path) {
     return *this;
 }
 
-
 score::Result<Kvs> KvsBuilder::build() {
     score::Result<Kvs> result = score::MakeUnexpected(ErrorCode::UnmappedError);
 
@@ -47,11 +46,8 @@ score::Result<Kvs> KvsBuilder::build() {
     }
 
     result = Kvs::open(
-        instance_id,
-        need_defaults ? OpenNeedDefaults::Required : OpenNeedDefaults::Optional,
-        need_kvs      ? OpenNeedKvs::Required      : OpenNeedKvs::Optional,
-        std::move(directory)
-    );
+        instance_id, need_defaults ? OpenNeedDefaults::Required : OpenNeedDefaults::Optional,
+        need_kvs ? OpenNeedKvs::Required : OpenNeedKvs::Optional, std::move(directory));
 
     return result;
 }

--- a/src/cpp/src/kvsbuilder.hpp
+++ b/src/cpp/src/kvsbuilder.hpp
@@ -57,7 +57,7 @@ namespace score::mw::per::kvs {
  * \endcode
  */
 class KvsBuilder final {
-public:
+   public:
     /**
      * @brief Constructs a KvsBuilder for the given KVS instance.
      * @param instance_id Unique identifier for the KVS instance.
@@ -96,11 +96,11 @@ public:
      */
     score::Result<Kvs> build();
 
-private:
-    InstanceId                         instance_id;   ///< ID of the KVS instance
-    bool                               need_defaults; ///< Whether default values are required
-    bool                               need_kvs;      ///< Whether an existing KVS is required
-    std::string                        directory;     ///< Directory where to store the KVS Files
+   private:
+    InstanceId instance_id;  ///< ID of the KVS instance
+    bool need_defaults;      ///< Whether default values are required
+    bool need_kvs;           ///< Whether an existing KVS is required
+    std::string directory;   ///< Directory where to store the KVS Files
 };
 
 } /* namespace score::mw::per::kvs */

--- a/src/cpp/src/kvsvalue.cpp
+++ b/src/cpp/src/kvsvalue.cpp
@@ -14,7 +14,7 @@
 
 namespace score::mw::per::kvs {
 
-KvsValue::KvsValue(const Array& array){
+KvsValue::KvsValue(const Array& array) {
     Array shared_array;
     shared_array.reserve(array.size());
     for (const auto& item : array) {
@@ -54,8 +54,8 @@ KvsValue::KvsValue(const std::unordered_map<std::string, KvsValue>& object) {
 
 /* copy constructor */
 KvsValue::KvsValue(const KvsValue& other) : type(other.type) {
-    switch(other.type){
-        case Type::Array:{
+    switch (other.type) {
+        case Type::Array: {
             const Array& otherArray = std::get<Array>(other.value);
             Array copiedArray;
             copiedArray.reserve(otherArray.size());
@@ -65,7 +65,7 @@ KvsValue::KvsValue(const KvsValue& other) : type(other.type) {
             value = std::move(copiedArray);
             break;
         }
-        case Type::Object:{
+        case Type::Object: {
             const Object& otherObject = std::get<Object>(other.value);
             Object copiedObject;
             for (const auto& [key, value] : otherObject) {
@@ -75,7 +75,7 @@ KvsValue::KvsValue(const KvsValue& other) : type(other.type) {
             break;
         }
         default:
-            value = other.value; // For other types, just copy the value
+            value = other.value;  // For other types, just copy the value
             break;
     }
 }
@@ -83,7 +83,7 @@ KvsValue::KvsValue(const KvsValue& other) : type(other.type) {
 /* copy Assignment Operator */
 KvsValue& KvsValue::operator=(const KvsValue& other) {
     if (this != &other) {
-        KvsValue temp(other); // deep copy
+        KvsValue temp(other);  // deep copy
         std::swap(value, temp.value);
         type = other.type;
     }

--- a/src/cpp/src/kvsvalue.hpp
+++ b/src/cpp/src/kvsvalue.hpp
@@ -59,24 +59,13 @@ namespace score::mw::per::kvs {
  */
 
 class KvsValue final {
-public:
+   public:
     /* Define the possible types for KvsValue*/
     using Array = std::vector<std::shared_ptr<KvsValue>>;
     using Object = std::unordered_map<std::string, std::shared_ptr<KvsValue>>;
 
     /* Enum to represent the type of the value*/
-    enum class Type {
-        i32,
-        u32,
-        i64,
-        u64,
-        f64,
-        Boolean,
-        String,
-        Null,
-        Array,
-        Object
-    };
+    enum class Type { i32, u32, i64, u64, f64, Boolean, String, Null, Array, Object };
 
     /* Constructors for each type*/
     explicit KvsValue(int32_t number) : value(number), type(Type::i32) {}
@@ -88,7 +77,7 @@ public:
     explicit KvsValue(const char* str) : value(std::string(str)), type(Type::String) {}
     explicit KvsValue(const std::string& str) : value(str), type(Type::String) {}
     explicit KvsValue(std::nullptr_t) : value(nullptr), type(Type::Null) {}
-    explicit KvsValue(const Array& array) ;
+    explicit KvsValue(const Array& array);
     explicit KvsValue(const Object& object);
     explicit KvsValue(const std::vector<KvsValue>& array);
     explicit KvsValue(const std::unordered_map<std::string, KvsValue>& object);
@@ -109,13 +98,17 @@ public:
     Type getType() const { return type; }
 
     /* Access the underlying value (use std::get to retrieve the value)*/
-    const std::variant<int32_t, uint32_t, int64_t, uint64_t, double, bool, std::string, std::nullptr_t, Array, Object>& getValue() const {
+    const std::variant<int32_t, uint32_t, int64_t, uint64_t, double, bool, std::string,
+                       std::nullptr_t, Array, Object>&
+    getValue() const {
         return value;
     }
 
-private:
+   private:
     /* The underlying value*/
-    std::variant<int32_t, uint32_t, int64_t, uint64_t, double, bool, std::string, std::nullptr_t, Array, Object> value;
+    std::variant<int32_t, uint32_t, int64_t, uint64_t, double, bool, std::string, std::nullptr_t,
+                 Array, Object>
+        value;
 
     /* The type of the value*/
     Type type;

--- a/src/cpp/tests/bm_kvs.cpp
+++ b/src/cpp/tests/bm_kvs.cpp
@@ -32,6 +32,6 @@ static void BM_get_hash_bytes(benchmark::State& state) {
 }
 
 // Register the function as a benchmark with different input sizes
-BENCHMARK(BM_get_hash_bytes)->Range(16, 16<<10);
+BENCHMARK(BM_get_hash_bytes)->Range(16, 16 << 10);
 
 BENCHMARK_MAIN();

--- a/src/cpp/tests/test_kvs.cpp
+++ b/src/cpp/tests/test_kvs.cpp
@@ -16,37 +16,38 @@ TEST(kvs_constructor, move_constructor) {
     const std::uint32_t instance_b = 5;
 
     /* create object A */
-    auto result_a = Kvs::open(InstanceId(instance_b), OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result_a = Kvs::open(InstanceId(instance_b), OpenNeedDefaults::Optional,
+                              OpenNeedKvs::Optional, std::string(data_dir));
     ASSERT_TRUE(result_a);
     Kvs kvs_a = std::move(result_a.value());
 
     /* create object B */
-    auto result_b = Kvs::open(instance_id , OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result_b = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                              std::string(data_dir));
     ASSERT_TRUE(result_b);
     Kvs kvs_b = std::move(result_b.value());
 
     /* Create Test Data*/
-    kvs_b.kvs.insert({ "test_kvs", KvsValue(42.0) });
-    kvs_b.default_values.insert({ "test_default", KvsValue(true) });
+    kvs_b.kvs.insert({"test_kvs", KvsValue(42.0)});
+    kvs_b.default_values.insert({"test_default", KvsValue(true)});
 
     /* Move assignment operator */
     kvs_a = std::move(kvs_b);
 
-    /* Ignore Compiler Warning "Wself-move" for GCC and CLANG*/
-    #if defined(__clang__)
-    #pragma clang diagnostic push
-    #pragma clang diagnostic ignored "-Wself-move"
-    #endif
-    kvs_a = std::move(kvs_a);  /* Intentional self-move */
-    #if defined(__clang__)
-    #pragma clang diagnostic pop
-    #endif
-
+/* Ignore Compiler Warning "Wself-move" for GCC and CLANG*/
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wself-move"
+#endif
+    kvs_a = std::move(kvs_a); /* Intentional self-move */
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 
     /*Expectations:
     - kvs_a now contains data from the former kvs_b (default JSON data) */
 
-    EXPECT_EQ(kvs_a.filename_prefix.CStr(), data_dir + "kvs_"+std::to_string(instance));
+    EXPECT_EQ(kvs_a.filename_prefix.CStr(), data_dir + "kvs_" + std::to_string(instance));
 
     EXPECT_TRUE(kvs_a.kvs.count("test_kvs"));
     EXPECT_TRUE(kvs_a.default_values.count("test_default"));
@@ -69,7 +70,8 @@ TEST(kvs_TEST, parse_json_data_sucess) {
     /* Success */
     prepare_environment();
 
-    auto kvs = Kvs::open(InstanceId(instance_id), OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto kvs = Kvs::open(InstanceId(instance_id), OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                         std::string(data_dir));
     ASSERT_TRUE(kvs);
 
     auto mock_parser = std::make_unique<score::json::IJsonParserMock>();
@@ -92,17 +94,18 @@ TEST(kvs_TEST, parse_json_data_sucess) {
 }
 
 TEST(kvs_TEST, parse_json_data_failure) {
-
     prepare_environment();
 
     /* Json Parser Failure */
 
-    auto kvs = Kvs::open(InstanceId(instance_id), OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto kvs = Kvs::open(InstanceId(instance_id), OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                         std::string(data_dir));
     ASSERT_TRUE(kvs);
 
     auto mock_parser = std::make_unique<score::json::IJsonParserMock>();
     EXPECT_CALL(*mock_parser, FromBuffer(::testing::_))
-        .WillOnce(::testing::Return(score::Result<score::json::Any>(score::MakeUnexpected(score::json::Error::kInvalidFilePath))));
+        .WillOnce(::testing::Return(score::Result<score::json::Any>(
+            score::MakeUnexpected(score::json::Error::kInvalidFilePath))));
 
     kvs->parser = std::move(mock_parser);
 
@@ -110,21 +113,20 @@ TEST(kvs_TEST, parse_json_data_failure) {
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), ErrorCode::JsonParserError);
 
-
     /* No Object returned Failure */
 
     mock_parser = std::make_unique<score::json::IJsonParserMock>();
     score::json::Any JsonParserReturnValue(42.0);
 
     EXPECT_CALL(*mock_parser, FromBuffer(::testing::_))
-        .WillOnce(::testing::Return(score::Result<score::json::Any>(std::move(JsonParserReturnValue))));
+        .WillOnce(
+            ::testing::Return(score::Result<score::json::Any>(std::move(JsonParserReturnValue))));
 
     kvs->parser = std::move(mock_parser);
 
     result = kvs->parse_json_data("data_not_used_in_mocking");
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), ErrorCode::JsonParserError);
-
 
     /* any_to_kvsvalue error */
 
@@ -143,16 +145,16 @@ TEST(kvs_TEST, parse_json_data_failure) {
 
     result = kvs->parse_json_data("data_not_used_in_mocking");
     EXPECT_FALSE(result.has_value());
-    EXPECT_EQ(result.error(), ErrorCode::InvalidValueType); //error is passed from any_to_kvsvalue
+    EXPECT_EQ(result.error(), ErrorCode::InvalidValueType);  // error is passed from any_to_kvsvalue
 
     cleanup_environment();
 }
 
 TEST(kvs_open_json, open_json_success) {
-
     prepare_environment();
 
-    auto kvs = Kvs::open(InstanceId(instance_id), OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto kvs = Kvs::open(InstanceId(instance_id), OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                         std::string(data_dir));
     ASSERT_TRUE(kvs);
 
     auto result = kvs->open_json(score::filesystem::Path(kvs_prefix), OpenJsonNeedFile::Required);
@@ -164,7 +166,6 @@ TEST(kvs_open_json, open_json_success) {
 }
 
 TEST(kvs_open_json, open_json_json_invalid) {
-
     prepare_environment();
     /* JSON Data invalid (parse_json_data Failure) */
     std::string invalid_json = "{ invalid json }";
@@ -176,23 +177,25 @@ TEST(kvs_open_json, open_json_json_invalid) {
     std::ofstream kvs_hash_file(kvs_prefix + ".hash", std::ios::binary);
     kvs_hash_file.put((kvs_hash >> 24) & 0xFF);
     kvs_hash_file.put((kvs_hash >> 16) & 0xFF);
-    kvs_hash_file.put((kvs_hash >> 8)  & 0xFF);
+    kvs_hash_file.put((kvs_hash >> 8) & 0xFF);
     kvs_hash_file.put(kvs_hash & 0xFF);
     kvs_hash_file.close();
 
-    Kvs kvs = Kvs(); /* Create Kvs instance without any data (this constructor is normally private) */
+    Kvs kvs =
+        Kvs(); /* Create Kvs instance without any data (this constructor is normally private) */
 
     /* Make JSON Parser Fail */
     auto mock_parser = std::make_unique<score::json::IJsonParserMock>();
-    EXPECT_CALL(*mock_parser, FromBuffer(::testing::_))
-        .WillRepeatedly([](auto) {
-            return score::Result<score::json::Any>(score::MakeUnexpected(score::json::Error::kInvalidFilePath));
-        });
+    EXPECT_CALL(*mock_parser, FromBuffer(::testing::_)).WillRepeatedly([](auto) {
+        return score::Result<score::json::Any>(
+            score::MakeUnexpected(score::json::Error::kInvalidFilePath));
+    });
     kvs.parser = std::move(mock_parser);
 
     auto result = kvs.open_json(score::filesystem::Path(kvs_prefix), OpenJsonNeedFile::Required);
     ASSERT_FALSE(result);
-    EXPECT_EQ(static_cast<ErrorCode>(*result.error()), ErrorCode::JsonParserError); /* Errorcode passed by parse json function*/
+    EXPECT_EQ(static_cast<ErrorCode>(*result.error()),
+              ErrorCode::JsonParserError); /* Errorcode passed by parse json function*/
 
     /* JSON not existing */
     system(("rm -rf " + kvs_prefix + ".json").c_str());
@@ -204,15 +207,16 @@ TEST(kvs_open_json, open_json_json_invalid) {
 }
 
 TEST(kvs_open_json, open_json_hash_invalid) {
-
     prepare_environment();
     /* Hash corrupted */
-    std::fstream corrupt_default_hash_file(kvs_prefix + ".hash", std::ios::in | std::ios::out | std::ios::binary);
+    std::fstream corrupt_default_hash_file(kvs_prefix + ".hash",
+                                           std::ios::in | std::ios::out | std::ios::binary);
     corrupt_default_hash_file.seekp(0);
     corrupt_default_hash_file.put(0xFF);
     corrupt_default_hash_file.close();
 
-    Kvs kvs = Kvs(); /* Create Kvs instance without any data (this constructor is normally private) */
+    Kvs kvs =
+        Kvs(); /* Create Kvs instance without any data (this constructor is normally private) */
 
     auto result = kvs.open_json(score::filesystem::Path(kvs_prefix), OpenJsonNeedFile::Optional);
     ASSERT_FALSE(result);
@@ -233,11 +237,10 @@ TEST(kvs_open_json, open_json_hash_invalid) {
     cleanup_environment();
 }
 
-
-TEST(kvs_reset, reset_success){
-
+TEST(kvs_reset, reset_success) {
     prepare_environment();
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Check Data existing */
@@ -251,12 +254,12 @@ TEST(kvs_reset, reset_success){
     cleanup_environment();
 }
 
-TEST(kvs_reset, reset_failure){
-
+TEST(kvs_reset, reset_failure) {
     prepare_environment();
 
     /* Mutex locked */
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     std::unique_lock<std::mutex> lock(result.value().kvs_mutex);
@@ -267,11 +270,11 @@ TEST(kvs_reset, reset_failure){
     cleanup_environment();
 }
 
-TEST(kvs_get_all_keys, get_all_keys_success){
-
+TEST(kvs_get_all_keys, get_all_keys_success) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Check Data existing */
@@ -282,7 +285,8 @@ TEST(kvs_get_all_keys, get_all_keys_success){
     ASSERT_TRUE(get_all_keys_result);
     EXPECT_FALSE(get_all_keys_result.value().empty());
 
-    auto search = std::find(get_all_keys_result.value().begin(), get_all_keys_result.value().end(), "kvs");
+    auto search =
+        std::find(get_all_keys_result.value().begin(), get_all_keys_result.value().end(), "kvs");
     EXPECT_TRUE(search != get_all_keys_result.value().end());
 
     /* Check if empty keys are returned */
@@ -293,12 +297,12 @@ TEST(kvs_get_all_keys, get_all_keys_success){
     cleanup_environment();
 }
 
-TEST(kvs_get_all_keys, get_all_keys_failure){
-
+TEST(kvs_get_all_keys, get_all_keys_failure) {
     prepare_environment();
 
     /* Mutex locked */
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
     std::unique_lock<std::mutex> lock(result.value().kvs_mutex);
 
@@ -309,11 +313,11 @@ TEST(kvs_get_all_keys, get_all_keys_failure){
     cleanup_environment();
 }
 
-TEST(kvs_key_exists, key_exists_success){
-
+TEST(kvs_key_exists, key_exists_success) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Check Data existing */
@@ -331,12 +335,12 @@ TEST(kvs_key_exists, key_exists_success){
     cleanup_environment();
 }
 
-TEST(kvs_key_exists, key_exists_failure){
-
+TEST(kvs_key_exists, key_exists_failure) {
     prepare_environment();
 
     /* Mutex locked */
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     std::unique_lock<std::mutex> lock(result.value().kvs_mutex);
@@ -347,11 +351,11 @@ TEST(kvs_key_exists, key_exists_failure){
     cleanup_environment();
 }
 
-TEST(kvs_get_value, get_value_success){
-
+TEST(kvs_get_value, get_value_success) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Check Data existing */
@@ -365,12 +369,10 @@ TEST(kvs_get_value, get_value_success){
 
     /* Check if default value is returned when no written key exists */
     result.value().kvs.clear();
-    ASSERT_TRUE(result.value().kvs.empty()); // Make sure kvs is empty and it uses the default value
+    ASSERT_TRUE(
+        result.value().kvs.empty());  // Make sure kvs is empty and it uses the default value
     int32_t default_value(42);
-    result.value().default_values.insert_or_assign(
-        "kvs",
-        KvsValue(default_value)
-    );
+    result.value().default_values.insert_or_assign("kvs", KvsValue(default_value));
     get_value_result = result.value().get_value("kvs");
     ASSERT_TRUE(get_value_result);
     EXPECT_EQ(get_value_result.value().getType(), KvsValue::Type::i32);
@@ -379,11 +381,11 @@ TEST(kvs_get_value, get_value_success){
     cleanup_environment();
 }
 
-TEST(kvs_get_value, get_value_failure){
-
+TEST(kvs_get_value, get_value_failure) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Check if non-existing key returns error */
@@ -392,7 +394,8 @@ TEST(kvs_get_value, get_value_failure){
     EXPECT_EQ(get_value_result.error(), ErrorCode::KeyNotFound);
 
     /* Mutex locked */
-    result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                       std::string(data_dir));
     ASSERT_TRUE(result);
     std::unique_lock<std::mutex> lock(result.value().kvs_mutex);
     get_value_result = result.value().get_value("kvs");
@@ -402,19 +405,16 @@ TEST(kvs_get_value, get_value_failure){
     cleanup_environment();
 }
 
-TEST(kvs_get_default_value, get_default_value_success){
-
+TEST(kvs_get_default_value, get_default_value_success) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Check Data existing */
     int32_t default_value(42);
-    result.value().default_values.insert_or_assign(
-        "kvs",
-        KvsValue(default_value)
-    );
+    result.value().default_values.insert_or_assign("kvs", KvsValue(default_value));
 
     /* Check if default value is returned */
     auto get_def_value_result = result.value().get_default_value("kvs");
@@ -425,11 +425,11 @@ TEST(kvs_get_default_value, get_default_value_success){
     cleanup_environment();
 }
 
-TEST(kvs_get_default_value, get_default_value_failure){
-
+TEST(kvs_get_default_value, get_default_value_failure) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Check if non-existing key returns error */
@@ -440,18 +440,16 @@ TEST(kvs_get_default_value, get_default_value_failure){
     cleanup_environment();
 }
 
-TEST(kvs_reset_key, reset_key_success){
-
+TEST(kvs_reset_key, reset_key_success) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
     ASSERT_TRUE(result.value().kvs.count("kvs")); /* Check Data existing */
 
-    result.value().default_values.insert_or_assign( /* Create default Value for "kvs"-key */
-        "kvs",
-        KvsValue(42.0)
-    );
+    result.value().default_values.insert_or_assign(/* Create default Value for "kvs"-key */
+                                                   "kvs", KvsValue(42.0));
     /* Reset a key */
     auto reset_key_result = result.value().reset_key("kvs");
     EXPECT_TRUE(reset_key_result);
@@ -459,21 +457,18 @@ TEST(kvs_reset_key, reset_key_success){
     EXPECT_TRUE(result.value().default_values.count("kvs"));
 
     /* Reset a non written key which has default value */
-    result.value().default_values.insert_or_assign(
-        "default",
-        KvsValue(42.0)
-    );
+    result.value().default_values.insert_or_assign("default", KvsValue(42.0));
     reset_key_result = result.value().reset_key("default");
     EXPECT_TRUE(reset_key_result);
 
     cleanup_environment();
 }
 
-TEST(kvs_reset_key, reset_key_failure){
-
+TEST(kvs_reset_key, reset_key_failure) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Reset a non-existing key */
@@ -482,15 +477,18 @@ TEST(kvs_reset_key, reset_key_failure){
     EXPECT_EQ(reset_key_result.error(), ErrorCode::KeyDefaultNotFound);
 
     /* Reset a key without default value */
-    result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                       std::string(data_dir));
     ASSERT_TRUE(result);
-    result.value().default_values.clear(); // Clear default values to ensure no default value exists for "kvs"
+    result.value().default_values.clear();  // Clear default values to ensure no default value
+                                            // exists for "kvs"
     reset_key_result = result.value().reset_key("kvs");
     EXPECT_FALSE(reset_key_result);
     EXPECT_EQ(reset_key_result.error(), ErrorCode::KeyDefaultNotFound);
 
     /* Mutex locked */
-    result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                       std::string(data_dir));
     ASSERT_TRUE(result);
     std::unique_lock<std::mutex> lock(result.value().kvs_mutex);
     reset_key_result = result.value().reset_key("kvs");
@@ -500,18 +498,15 @@ TEST(kvs_reset_key, reset_key_failure){
     cleanup_environment();
 }
 
-TEST(kvs_has_default_value, has_default_value){
-
+TEST(kvs_has_default_value, has_default_value) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Create Test Default Data */
-    result.value().default_values.insert_or_assign(
-        "default",
-        KvsValue(42.0)
-    );
+    result.value().default_values.insert_or_assign("default", KvsValue(42.0));
 
     /* Check if default value exists */
     auto has_default_result = result.value().has_default_value("default");
@@ -526,10 +521,10 @@ TEST(kvs_has_default_value, has_default_value){
     cleanup_environment();
 }
 
-TEST(kvs_set_value, set_value_success){
-
+TEST(kvs_set_value, set_value_success) {
     prepare_environment();
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Set a new value */
@@ -548,12 +543,12 @@ TEST(kvs_set_value, set_value_success){
     cleanup_environment();
 }
 
-TEST(kvs_set_value, set_value_failure){
-
+TEST(kvs_set_value, set_value_failure) {
     prepare_environment();
 
     /* Mutex locked */
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     std::unique_lock<std::mutex> lock(result.value().kvs_mutex);
@@ -564,10 +559,10 @@ TEST(kvs_set_value, set_value_failure){
     cleanup_environment();
 }
 
-TEST(kvs_remove_key, remove_key_success){
-
+TEST(kvs_remove_key, remove_key_success) {
     prepare_environment();
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Check Data existing */
@@ -581,11 +576,11 @@ TEST(kvs_remove_key, remove_key_success){
     cleanup_environment();
 }
 
-TEST(kvs_remove_key, remove_key_failure){
-
+TEST(kvs_remove_key, remove_key_failure) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Remove a non-existing key */
@@ -594,7 +589,8 @@ TEST(kvs_remove_key, remove_key_failure){
     EXPECT_EQ(remove_key_result.error(), ErrorCode::KeyNotFound);
 
     /* Mutex locked */
-    result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required, std::string(data_dir));
+    result = Kvs::open(instance_id, OpenNeedDefaults::Required, OpenNeedKvs::Required,
+                       std::string(data_dir));
     ASSERT_TRUE(result);
     std::unique_lock<std::mutex> lock(result.value().kvs_mutex);
     remove_key_result = result.value().remove_key("kvs");
@@ -604,8 +600,7 @@ TEST(kvs_remove_key, remove_key_failure){
     cleanup_environment();
 }
 
-TEST(kvs_write_json_data, write_json_data_success){
-
+TEST(kvs_write_json_data, write_json_data_success) {
     prepare_environment();
     /* Test writing valid JSON data, also checks get_hash_bytes_adler32 and get_hash_bytes*/
     const char* json_test_data = R"({
@@ -617,10 +612,12 @@ TEST(kvs_write_json_data, write_json_data_success){
     system(("rm -rf " + kvs_prefix + ".json").c_str());
     system(("rm -rf " + kvs_prefix + ".hash").c_str());
 
-    auto kvs = Kvs::open(InstanceId(instance_id), OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto kvs = Kvs::open(InstanceId(instance_id), OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                         std::string(data_dir));
     ASSERT_TRUE(kvs);
 
-    kvs->filename_prefix = score::filesystem::Path(filename_prefix); /* Set the filename prefix to the test prefix */
+    kvs->filename_prefix =
+        score::filesystem::Path(filename_prefix); /* Set the filename prefix to the test prefix */
     auto result = kvs->write_json_data(json_test_data);
     EXPECT_TRUE(result);
     EXPECT_TRUE(std::filesystem::exists(kvs_prefix + ".json"));
@@ -628,71 +625,77 @@ TEST(kvs_write_json_data, write_json_data_success){
 
     /* Check if the content and hash is correct */
     std::ifstream in_content(kvs_prefix + ".json", std::ios::binary);
-    std::string file_content((std::istreambuf_iterator<char>(in_content)), std::istreambuf_iterator<char>());
+    std::string file_content((std::istreambuf_iterator<char>(in_content)),
+                             std::istreambuf_iterator<char>());
     in_content.close();
     EXPECT_EQ(file_content, json_test_data);
     std::ifstream in_hash(kvs_prefix + ".hash", std::ios::binary);
-    std::string hash_content((std::istreambuf_iterator<char>(in_hash)), std::istreambuf_iterator<char>());
+    std::string hash_content((std::istreambuf_iterator<char>(in_hash)),
+                             std::istreambuf_iterator<char>());
     in_hash.close();
     uint32_t hash = adler32(json_test_data);
-    std::array<uint8_t, 4> hash_bytes = {
-        uint8_t((hash >> 24) & 0xFF),
-        uint8_t((hash >> 16) & 0xFF),
-        uint8_t((hash >>  8) & 0xFF),
-        uint8_t((hash      ) & 0xFF)
-    };
-    std::string expected_hash_string(reinterpret_cast<const char*>(hash_bytes.data()), hash_bytes.size());
+    std::array<uint8_t, 4> hash_bytes = {uint8_t((hash >> 24) & 0xFF), uint8_t((hash >> 16) & 0xFF),
+                                         uint8_t((hash >> 8) & 0xFF), uint8_t((hash) & 0xFF)};
+    std::string expected_hash_string(reinterpret_cast<const char*>(hash_bytes.data()),
+                                     hash_bytes.size());
     EXPECT_EQ(hash_content, expected_hash_string);
 
     cleanup_environment();
 }
 
-TEST(kvs_write_json_data, write_json_data_filesystem_failure){
-
+TEST(kvs_write_json_data, write_json_data_filesystem_failure) {
     prepare_environment();
     /* Test CreateDirectories fails */
     system(("rm -rf " + kvs_prefix + ".json").c_str());
     system(("rm -rf " + kvs_prefix + ".hash").c_str());
 
-    auto kvs = Kvs::open(InstanceId(instance_id), OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto kvs = Kvs::open(InstanceId(instance_id), OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                         std::string(data_dir));
     ASSERT_TRUE(kvs);
 
     /* Mock Filesystem */
     score::filesystem::Filesystem mock_filesystem = score::filesystem::CreateMockFileSystem();
-    auto standard_mock = std::dynamic_pointer_cast<score::filesystem::StandardFilesystemMock>(mock_filesystem.standard);
+    auto standard_mock = std::dynamic_pointer_cast<score::filesystem::StandardFilesystemMock>(
+        mock_filesystem.standard);
     ASSERT_NE(standard_mock, nullptr);
     EXPECT_CALL(*standard_mock, CreateDirectories(::testing::_))
-        .WillOnce(::testing::Return(score::ResultBlank(score::MakeUnexpected(score::filesystem::ErrorCode::kCouldNotCreateDirectory))));
-    kvs.value().filesystem = std::make_unique<score::filesystem::Filesystem>(std::move(mock_filesystem));
+        .WillOnce(::testing::Return(score::ResultBlank(
+            score::MakeUnexpected(score::filesystem::ErrorCode::kCouldNotCreateDirectory))));
+    kvs.value().filesystem =
+        std::make_unique<score::filesystem::Filesystem>(std::move(mock_filesystem));
 
     auto result = kvs->write_json_data(kvs_json);
     EXPECT_FALSE(result);
     EXPECT_EQ(result.error(), ErrorCode::PhysicalStorageFailure);
 
-
-    /* Test if path argument is missing parent path (will only occur if semantic errors will be done in flush() )*/
-    kvs->filename_prefix = score::filesystem::Path("no_parent_path"); /* Set the filename prefix to the test prefix */
+    /* Test if path argument is missing parent path (will only occur if semantic errors will be done
+     * in flush() )*/
+    kvs->filename_prefix =
+        score::filesystem::Path("no_parent_path"); /* Set the filename prefix to the test prefix */
     result = kvs->write_json_data(kvs_json);
     EXPECT_FALSE(result);
     EXPECT_EQ(result.error(), ErrorCode::PhysicalStorageFailure);
 
     cleanup_environment();
 }
-TEST(kvs_write_json_data, write_json_data_permissions_failure){
+TEST(kvs_write_json_data, write_json_data_permissions_failure) {
     prepare_environment();
     /* Test CreateDirectories fails */
     system(("rm -rf " + kvs_prefix + ".json").c_str());
     system(("rm -rf " + kvs_prefix + ".hash").c_str());
 
-    auto kvs = Kvs::open(InstanceId(instance_id), OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto kvs = Kvs::open(InstanceId(instance_id), OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                         std::string(data_dir));
     ASSERT_TRUE(kvs);
 
-     /* Test writing to a non-writable hash file */
+    /* Test writing to a non-writable hash file */
     std::ofstream out_hash(kvs_prefix + ".hash");
     out_hash << "data";
     out_hash.close();
-    std::filesystem::permissions(kvs_prefix + ".hash", std::filesystem::perms::owner_read, std::filesystem::perm_options::replace);
-    kvs->filename_prefix = score::filesystem::Path(filename_prefix); /* Reset the filename prefix to the test prefix */
+    std::filesystem::permissions(kvs_prefix + ".hash", std::filesystem::perms::owner_read,
+                                 std::filesystem::perm_options::replace);
+    kvs->filename_prefix =
+        score::filesystem::Path(filename_prefix); /* Reset the filename prefix to the test prefix */
     auto result = kvs->write_json_data(kvs_json);
     EXPECT_FALSE(result);
     EXPECT_EQ(result.error(), ErrorCode::PhysicalStorageFailure);
@@ -701,21 +704,22 @@ TEST(kvs_write_json_data, write_json_data_permissions_failure){
     std::ofstream out_json(kvs_prefix + ".json");
     out_json << "data";
     out_json.close();
-    std::filesystem::permissions(kvs_prefix + ".json", std::filesystem::perms::owner_read, std::filesystem::perm_options::replace);
-    kvs->filename_prefix = score::filesystem::Path(filename_prefix); /* Reset the filename prefix to the test prefix */
+    std::filesystem::permissions(kvs_prefix + ".json", std::filesystem::perms::owner_read,
+                                 std::filesystem::perm_options::replace);
+    kvs->filename_prefix =
+        score::filesystem::Path(filename_prefix); /* Reset the filename prefix to the test prefix */
     result = kvs->write_json_data(kvs_json);
     EXPECT_FALSE(result);
     EXPECT_EQ(result.error(), ErrorCode::PhysicalStorageFailure);
 
     cleanup_environment();
-
 }
 
-TEST(kvs_snapshot_rotate, snapshot_rotate_success){
-
+TEST(kvs_snapshot_rotate, snapshot_rotate_success) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Create empty Test-Snapshot Files */
@@ -724,27 +728,31 @@ TEST(kvs_snapshot_rotate, snapshot_rotate_success){
         std::ofstream(filename_prefix + "_" + std::to_string(i) + ".hash") << "{}";
         EXPECT_EQ(result.value().snapshot_count().value(), i);
     }
-    ASSERT_FALSE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) + ".json"));
-    ASSERT_FALSE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) + ".hash"));
+    ASSERT_FALSE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) +
+                                         ".json"));
+    ASSERT_FALSE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) +
+                                         ".hash"));
 
     /* Rotate Snapshots */
     auto rotate_result = result.value().snapshot_rotate();
     ASSERT_TRUE(rotate_result);
 
     /* Check if the snapshot ids are rotated and no ID 0 exists */
-    EXPECT_TRUE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) + ".json"));
-    EXPECT_TRUE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) + ".hash"));
+    EXPECT_TRUE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) +
+                                        ".json"));
+    EXPECT_TRUE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) +
+                                        ".hash"));
     EXPECT_FALSE(std::filesystem::exists(filename_prefix + "_" + std::to_string(0) + ".json"));
     EXPECT_FALSE(std::filesystem::exists(filename_prefix + "_" + std::to_string(0) + ".hash"));
 
     cleanup_environment();
 }
 
-TEST(kvs_snapshot_rotate, snapshot_rotate_max_snapshots){
-
+TEST(kvs_snapshot_rotate, snapshot_rotate_max_snapshots) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Create empty Test-Snapshot Files */
@@ -753,23 +761,27 @@ TEST(kvs_snapshot_rotate, snapshot_rotate_max_snapshots){
         std::ofstream(filename_prefix + "_" + std::to_string(i) + ".hash") << "{}";
         EXPECT_EQ(result.value().snapshot_count().value(), i);
     }
-    ASSERT_FALSE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) + ".json"));
-    ASSERT_FALSE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) + ".hash"));
+    ASSERT_FALSE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) +
+                                         ".json"));
+    ASSERT_FALSE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) +
+                                         ".hash"));
 
     /* Check if no ID higher than KVS_MAX_SNAPSHOTS exists */
     auto rotate_result = result.value().snapshot_rotate();
     ASSERT_TRUE(rotate_result);
-    EXPECT_FALSE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS + 1) + ".json"));
-    EXPECT_FALSE(std::filesystem::exists(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS + 1) + ".hash"));
+    EXPECT_FALSE(std::filesystem::exists(filename_prefix + "_" +
+                                         std::to_string(KVS_MAX_SNAPSHOTS + 1) + ".json"));
+    EXPECT_FALSE(std::filesystem::exists(filename_prefix + "_" +
+                                         std::to_string(KVS_MAX_SNAPSHOTS + 1) + ".hash"));
 
     cleanup_environment();
 }
 
-TEST(kvs_snapshot_rotate, snapshot_rotate_failure_renaming_json){
-
+TEST(kvs_snapshot_rotate, snapshot_rotate_failure_renaming_json) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Create empty Test-Snapshot Files */
@@ -779,8 +791,10 @@ TEST(kvs_snapshot_rotate, snapshot_rotate_failure_renaming_json){
         EXPECT_EQ(result.value().snapshot_count().value(), i);
     }
 
-    /* Snapshot (JSON) Renaming failed (Create directorys instead of json files to trigger rename error)*/
-    std::filesystem::create_directory(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) + ".json");
+    /* Snapshot (JSON) Renaming failed (Create directorys instead of json files to trigger rename
+     * error)*/
+    std::filesystem::create_directory(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) +
+                                      ".json");
     auto rotate_result = result.value().snapshot_rotate();
     EXPECT_FALSE(rotate_result);
     EXPECT_EQ(static_cast<ErrorCode>(*rotate_result.error()), ErrorCode::PhysicalStorageFailure);
@@ -788,11 +802,11 @@ TEST(kvs_snapshot_rotate, snapshot_rotate_failure_renaming_json){
     cleanup_environment();
 }
 
-TEST(kvs_snapshot_rotate, snapshot_rotate_failure_renaming_hash){
-
+TEST(kvs_snapshot_rotate, snapshot_rotate_failure_renaming_hash) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Create empty Test-Snapshot Files */
@@ -803,7 +817,8 @@ TEST(kvs_snapshot_rotate, snapshot_rotate_failure_renaming_hash){
     }
 
     /* Hash Renaming failed (Create directorys instead of json files to trigger rename error)*/
-    std::filesystem::create_directory(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) + ".hash");
+    std::filesystem::create_directory(filename_prefix + "_" + std::to_string(KVS_MAX_SNAPSHOTS) +
+                                      ".hash");
     auto rotate_result = result.value().snapshot_rotate();
     EXPECT_FALSE(rotate_result);
     EXPECT_EQ(static_cast<ErrorCode>(*rotate_result.error()), ErrorCode::PhysicalStorageFailure);
@@ -811,11 +826,11 @@ TEST(kvs_snapshot_rotate, snapshot_rotate_failure_renaming_hash){
     cleanup_environment();
 }
 
-TEST(kvs_snapshot_rotate, snapshot_rotate_failure_mutex){
-
+TEST(kvs_snapshot_rotate, snapshot_rotate_failure_mutex) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Mutex locked */
@@ -827,14 +842,14 @@ TEST(kvs_snapshot_rotate, snapshot_rotate_failure_mutex){
     cleanup_environment();
 }
 
-TEST(kvs_flush, flush_success_data){
-
+TEST(kvs_flush, flush_success_data) {
     prepare_environment();
     /* Test flush with valid data */
     system(("rm -rf " + kvs_prefix + ".json").c_str());
     system(("rm -rf " + kvs_prefix + ".hash").c_str());
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     result.value().kvs.clear(); /* Clear KVS to ensure no data is written */
@@ -852,22 +867,23 @@ TEST(kvs_flush, flush_success_data){
     cleanup_environment();
 }
 
-TEST(kvs_flush, flush_success_snapshot_rotate){
-
+TEST(kvs_flush, flush_success_snapshot_rotate) {
     prepare_environment();
 
     /* Test flush with valid data */
     system(("rm -rf " + kvs_prefix + ".json").c_str());
     system(("rm -rf " + kvs_prefix + ".hash").c_str());
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
     EXPECT_FALSE(std::filesystem::exists(filename_prefix + "_1.json"));
     EXPECT_FALSE(std::filesystem::exists(filename_prefix + "_1.hash"));
 
     result.value().flush(); /* Initial Flush -> SnapshotID 0 */
 
-    /* Check if snapshot_rotate was triggered on second flush --> one snapshot should be available afterwards */
+    /* Check if snapshot_rotate was triggered on second flush --> one snapshot should be available
+     * afterwards */
     auto flush_result = result.value().flush();
     ASSERT_TRUE(flush_result);
     EXPECT_TRUE(std::filesystem::exists(filename_prefix + "_1.json"));
@@ -876,11 +892,11 @@ TEST(kvs_flush, flush_success_snapshot_rotate){
     cleanup_environment();
 }
 
-TEST(kvs_flush, flush_failure_mutex){
-
+TEST(kvs_flush, flush_failure_mutex) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     std::unique_lock<std::mutex> lock(result.value().kvs_mutex);
@@ -891,16 +907,17 @@ TEST(kvs_flush, flush_failure_mutex){
     cleanup_environment();
 }
 
-TEST(kvs_flush, flush_failure_rotate_snapshots){
-
+TEST(kvs_flush, flush_failure_rotate_snapshots) {
     prepare_environment();
     /* Test Folder for permission handling */
     std::string permissions_dir = data_dir + "permissions/";
     std::filesystem::create_directories(permissions_dir);
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(permissions_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(permissions_dir));
     ASSERT_TRUE(result);
 
-    std::filesystem::permissions(permissions_dir, std::filesystem::perms::owner_read, std::filesystem::perm_options::replace);
+    std::filesystem::permissions(permissions_dir, std::filesystem::perms::owner_read,
+                                 std::filesystem::perm_options::replace);
     auto flush_result = result.value().flush();
 
     EXPECT_FALSE(flush_result);
@@ -909,11 +926,11 @@ TEST(kvs_flush, flush_failure_rotate_snapshots){
     cleanup_environment();
 }
 
-TEST(kvs_flush, flush_failure_kvsvalue_invalid){
-
+TEST(kvs_flush, flush_failure_kvsvalue_invalid) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     BrokenKvsValue invalid;
@@ -926,16 +943,18 @@ TEST(kvs_flush, flush_failure_kvsvalue_invalid){
     cleanup_environment();
 }
 
-TEST(kvs_flush, flush_failure_json_writer){
-
+TEST(kvs_flush, flush_failure_json_writer) {
     prepare_environment();
 
-    auto kvs = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto kvs = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                         std::string(data_dir));
     ASSERT_TRUE(kvs);
 
-    auto mock_writer = std::make_unique<score::json::IJsonWriterMock>(); /* Force error in writer.ToBuffer */
+    auto mock_writer =
+        std::make_unique<score::json::IJsonWriterMock>(); /* Force error in writer.ToBuffer */
     EXPECT_CALL(*mock_writer, ToBuffer(::testing::A<const score::json::Object&>()))
-        .WillOnce(::testing::Return(score::Result<std::string>(score::MakeUnexpected(score::json::Error::kUnknownError))));
+        .WillOnce(::testing::Return(
+            score::Result<std::string>(score::MakeUnexpected(score::json::Error::kUnknownError))));
 
     kvs->writer = std::move(mock_writer);
     auto result = kvs.value().flush();
@@ -945,11 +964,11 @@ TEST(kvs_flush, flush_failure_json_writer){
     cleanup_environment();
 }
 
-TEST(kvs_snapshot_count, snapshot_count_success){
-
+TEST(kvs_snapshot_count, snapshot_count_success) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Create empty Test-Snapshot Files */
@@ -968,34 +987,38 @@ TEST(kvs_snapshot_count, snapshot_count_success){
     cleanup_environment();
 }
 
-TEST(kvs_snapshot_count, snapshot_count_invalid){
+TEST(kvs_snapshot_count, snapshot_count_invalid) {
     prepare_environment();
 
-    auto kvs = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto kvs = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                         std::string(data_dir));
     ASSERT_TRUE(kvs);
 
     /* Mock Filesystem */
     score::filesystem::Filesystem mock_filesystem = score::filesystem::CreateMockFileSystem();
-    auto standard_mock = std::dynamic_pointer_cast<score::filesystem::StandardFilesystemMock>(mock_filesystem.standard);
+    auto standard_mock = std::dynamic_pointer_cast<score::filesystem::StandardFilesystemMock>(
+        mock_filesystem.standard);
     ASSERT_NE(standard_mock, nullptr);
     EXPECT_CALL(*standard_mock, Exists(::testing::_))
-        .WillOnce(::testing::Return(score::Result<bool>(score::MakeUnexpected(score::filesystem::ErrorCode::kCouldNotRetrieveStatus))));
-    kvs.value().filesystem = std::make_unique<score::filesystem::Filesystem>(std::move(mock_filesystem));
+        .WillOnce(::testing::Return(score::Result<bool>(
+            score::MakeUnexpected(score::filesystem::ErrorCode::kCouldNotRetrieveStatus))));
+    kvs.value().filesystem =
+        std::make_unique<score::filesystem::Filesystem>(std::move(mock_filesystem));
 
     auto result = kvs.value().snapshot_count();
     EXPECT_FALSE(result);
     EXPECT_EQ(static_cast<ErrorCode>(*result.error()), ErrorCode::PhysicalStorageFailure);
 }
 
-
-TEST(kvs_snapshot_restore, snapshot_restore_success){
-
+TEST(kvs_snapshot_restore, snapshot_restore_success) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
-    /* Create empty Test-Snapshot Files -> Data received by the JsonParser should be the data listed below */
+    /* Create empty Test-Snapshot Files -> Data received by the JsonParser should be the data listed
+     * below */
     ASSERT_FALSE(result.value().kvs.empty());
     ASSERT_FALSE(result.value().kvs.count("key1"));
     ASSERT_TRUE(result.value().kvs.count("kvs"));
@@ -1012,12 +1035,8 @@ TEST(kvs_snapshot_restore, snapshot_restore_success){
     out.write(json_data.data(), json_data.size());
     out.close();
     uint32_t hash = adler32(json_data);
-    std::array<uint8_t, 4> hash_bytes = {
-        uint8_t((hash >> 24) & 0xFF),
-        uint8_t((hash >> 16) & 0xFF),
-        uint8_t((hash >>  8) & 0xFF),
-        uint8_t((hash      ) & 0xFF)
-    };
+    std::array<uint8_t, 4> hash_bytes = {uint8_t((hash >> 24) & 0xFF), uint8_t((hash >> 16) & 0xFF),
+                                         uint8_t((hash >> 8) & 0xFF), uint8_t((hash) & 0xFF)};
     std::ofstream hash_out(filename_prefix + "_1.hash", std::ios::binary);
     hash_out.write(reinterpret_cast<const char*>(hash_bytes.data()), hash_bytes.size());
     hash_out.close();
@@ -1027,14 +1046,13 @@ TEST(kvs_snapshot_restore, snapshot_restore_success){
     EXPECT_TRUE(result.value().kvs.count("kvs_old"));
 
     cleanup_environment();
-
 }
 
-TEST(kvs_snapshot_restore, snapshot_restore_failure_invalid_snapshot_id){
-
+TEST(kvs_snapshot_restore, snapshot_restore_failure_invalid_snapshot_id) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Restore Snapshot ID 0 -> Current KVS*/
@@ -1050,29 +1068,31 @@ TEST(kvs_snapshot_restore, snapshot_restore_failure_invalid_snapshot_id){
     cleanup_environment();
 }
 
-TEST(kvs_snapshot_restore, snapshot_restore_failure_open_json){
-
+TEST(kvs_snapshot_restore, snapshot_restore_failure_open_json) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Create empty Test-Snapshot Files */
     std::ofstream(filename_prefix + "_1.json") << "{}"; /* Empty JSON */
-    std::ofstream(filename_prefix + "_1.hash") << "invalid_hash"; /* Invalid Hash -> Trigger open_json error */
+    std::ofstream(filename_prefix + "_1.hash")
+        << "invalid_hash"; /* Invalid Hash -> Trigger open_json error */
 
     auto restore_result = result.value().snapshot_restore(1);
     EXPECT_FALSE(restore_result);
-    EXPECT_EQ(static_cast<ErrorCode>(*restore_result.error()), ErrorCode::ValidationFailed); /* passed by open_json*/
+    EXPECT_EQ(static_cast<ErrorCode>(*restore_result.error()),
+              ErrorCode::ValidationFailed); /* passed by open_json*/
 
     cleanup_environment();
 }
 
-TEST(kvs_snapshot_restore, snapshot_restore_failure_mutex){
-
+TEST(kvs_snapshot_restore, snapshot_restore_failure_mutex) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     std::unique_lock<std::mutex> lock(result.value().kvs_mutex);
@@ -1083,20 +1103,23 @@ TEST(kvs_snapshot_restore, snapshot_restore_failure_mutex){
     cleanup_environment();
 }
 
-TEST(kvs_snapshot_restore, snapshot_restore_failure_snapshot_count){
-
+TEST(kvs_snapshot_restore, snapshot_restore_failure_snapshot_count) {
     prepare_environment();
 
-    auto kvs = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto kvs = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                         std::string(data_dir));
     ASSERT_TRUE(kvs);
 
     /* Mock Filesystem */
     score::filesystem::Filesystem mock_filesystem = score::filesystem::CreateMockFileSystem();
-    auto standard_mock = std::dynamic_pointer_cast<score::filesystem::StandardFilesystemMock>(mock_filesystem.standard);
+    auto standard_mock = std::dynamic_pointer_cast<score::filesystem::StandardFilesystemMock>(
+        mock_filesystem.standard);
     ASSERT_NE(standard_mock, nullptr);
     EXPECT_CALL(*standard_mock, Exists(::testing::_))
-        .WillOnce(::testing::Return(score::Result<bool>(score::MakeUnexpected(score::filesystem::ErrorCode::kCouldNotRetrieveStatus))));
-    kvs.value().filesystem = std::make_unique<score::filesystem::Filesystem>(std::move(mock_filesystem));
+        .WillOnce(::testing::Return(score::Result<bool>(
+            score::MakeUnexpected(score::filesystem::ErrorCode::kCouldNotRetrieveStatus))));
+    kvs.value().filesystem =
+        std::make_unique<score::filesystem::Filesystem>(std::move(mock_filesystem));
 
     auto result = kvs.value().snapshot_restore(1);
     EXPECT_FALSE(result);
@@ -1104,22 +1127,22 @@ TEST(kvs_snapshot_restore, snapshot_restore_failure_snapshot_count){
     cleanup_environment();
 }
 
-TEST(kvs_snapshot_max_count, snapshot_max_count){
-
+TEST(kvs_snapshot_max_count, snapshot_max_count) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
     EXPECT_EQ(result.value().snapshot_max_count(), KVS_MAX_SNAPSHOTS);
 
     cleanup_environment();
 }
 
-TEST(kvs_get_filename, get_kvs_filename_success){
-
+TEST(kvs_get_filename, get_kvs_filename_success) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Generate Testfiles */
@@ -1127,7 +1150,7 @@ TEST(kvs_get_filename, get_kvs_filename_success){
         std::ofstream(filename_prefix + "_" + std::to_string(i) + ".json") << "{}";
     }
 
-    for(int i = 0; i< KVS_MAX_SNAPSHOTS; i++) {
+    for (int i = 0; i < KVS_MAX_SNAPSHOTS; i++) {
         auto filename = result.value().get_kvs_filename(SnapshotId(i));
         EXPECT_TRUE(filename);
         EXPECT_EQ(filename.value().CStr(), filename_prefix + "_" + std::to_string(i) + ".json");
@@ -1136,11 +1159,11 @@ TEST(kvs_get_filename, get_kvs_filename_success){
     cleanup_environment();
 }
 
-TEST(kvs_get_filename, get_kvs_filename_failure){
-
+TEST(kvs_get_filename, get_kvs_filename_failure) {
     prepare_environment();
 
-    auto kvs = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto kvs = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                         std::string(data_dir));
     ASSERT_TRUE(kvs);
 
     /* Testfiles not available */
@@ -1151,11 +1174,14 @@ TEST(kvs_get_filename, get_kvs_filename_failure){
     /* Filesystem exists error */
     /* Mock Filesystem */
     score::filesystem::Filesystem mock_filesystem = score::filesystem::CreateMockFileSystem();
-    auto standard_mock = std::dynamic_pointer_cast<score::filesystem::StandardFilesystemMock>(mock_filesystem.standard);
+    auto standard_mock = std::dynamic_pointer_cast<score::filesystem::StandardFilesystemMock>(
+        mock_filesystem.standard);
     ASSERT_NE(standard_mock, nullptr);
     EXPECT_CALL(*standard_mock, Exists(::testing::_))
-        .WillOnce(::testing::Return(score::Result<bool>(score::MakeUnexpected(score::filesystem::ErrorCode::kCouldNotRetrieveStatus))));
-    kvs.value().filesystem = std::make_unique<score::filesystem::Filesystem>(std::move(mock_filesystem));
+        .WillOnce(::testing::Return(score::Result<bool>(
+            score::MakeUnexpected(score::filesystem::ErrorCode::kCouldNotRetrieveStatus))));
+    kvs.value().filesystem =
+        std::make_unique<score::filesystem::Filesystem>(std::move(mock_filesystem));
 
     result = kvs.value().get_kvs_filename(SnapshotId(1));
     EXPECT_FALSE(result);
@@ -1163,11 +1189,11 @@ TEST(kvs_get_filename, get_kvs_filename_failure){
     cleanup_environment();
 }
 
-TEST(kvs_get_filename, get_hashname_success){
-
+TEST(kvs_get_filename, get_hashname_success) {
     prepare_environment();
 
-    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto result = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                            std::string(data_dir));
     ASSERT_TRUE(result);
 
     /* Generate Testfiles */
@@ -1175,7 +1201,7 @@ TEST(kvs_get_filename, get_hashname_success){
         std::ofstream(filename_prefix + "_" + std::to_string(i) + ".hash") << "{}";
     }
 
-    for(int i = 0; i< KVS_MAX_SNAPSHOTS; i++) {
+    for (int i = 0; i < KVS_MAX_SNAPSHOTS; i++) {
         auto hashname = result.value().get_hash_filename(SnapshotId(i));
         system("ls -l ./data_folder/");
         EXPECT_TRUE(hashname);
@@ -1185,11 +1211,11 @@ TEST(kvs_get_filename, get_hashname_success){
     cleanup_environment();
 }
 
-TEST(kvs_get_filename, get_hashname_failure){
-
+TEST(kvs_get_filename, get_hashname_failure) {
     prepare_environment();
 
-    auto kvs = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional, std::string(data_dir));
+    auto kvs = Kvs::open(instance_id, OpenNeedDefaults::Optional, OpenNeedKvs::Optional,
+                         std::string(data_dir));
     ASSERT_TRUE(kvs);
 
     /* Testfiles not available */
@@ -1200,11 +1226,14 @@ TEST(kvs_get_filename, get_hashname_failure){
     /* Filesystem exists error */
     /* Mock Filesystem */
     score::filesystem::Filesystem mock_filesystem = score::filesystem::CreateMockFileSystem();
-    auto standard_mock = std::dynamic_pointer_cast<score::filesystem::StandardFilesystemMock>(mock_filesystem.standard);
+    auto standard_mock = std::dynamic_pointer_cast<score::filesystem::StandardFilesystemMock>(
+        mock_filesystem.standard);
     ASSERT_NE(standard_mock, nullptr);
     EXPECT_CALL(*standard_mock, Exists(::testing::_))
-        .WillOnce(::testing::Return(score::Result<bool>(score::MakeUnexpected(score::filesystem::ErrorCode::kCouldNotRetrieveStatus))));
-    kvs.value().filesystem = std::make_unique<score::filesystem::Filesystem>(std::move(mock_filesystem));
+        .WillOnce(::testing::Return(score::Result<bool>(
+            score::MakeUnexpected(score::filesystem::ErrorCode::kCouldNotRetrieveStatus))));
+    kvs.value().filesystem =
+        std::make_unique<score::filesystem::Filesystem>(std::move(mock_filesystem));
 
     result = kvs.value().get_hash_filename(SnapshotId(1));
     EXPECT_FALSE(result);

--- a/src/cpp/tests/test_kvs_builder.cpp
+++ b/src/cpp/tests/test_kvs_builder.cpp
@@ -12,7 +12,6 @@
  ********************************************************************************/
 #include "test_kvs_general.hpp"
 
-
 TEST(kvs_kvsbuilder, kvsbuilder_build) {
     /* This test also checks the kvs open function with the KvsBuilder */
 
@@ -35,34 +34,40 @@ TEST(kvs_kvsbuilder, kvsbuilder_build) {
     open() function should return an error, since the files are not available */
     auto result_build = builder.build();
     ASSERT_FALSE(result_build);
-    EXPECT_EQ(static_cast<ErrorCode>(*result_build.error()), ErrorCode::KvsFileReadError); /* This error occurs in open_json and is passed through open()*/
+    EXPECT_EQ(static_cast<ErrorCode>(*result_build.error()),
+              ErrorCode::KvsFileReadError); /* This error occurs in open_json and is passed through
+                                               open()*/
     builder.need_defaults_flag(false);
     result_build = builder.build();
     ASSERT_FALSE(result_build);
-    EXPECT_EQ(static_cast<ErrorCode>(*result_build.error()), ErrorCode::KvsFileReadError); /* This error occurs in open_json and is passed through open()*/
+    EXPECT_EQ(static_cast<ErrorCode>(*result_build.error()),
+              ErrorCode::KvsFileReadError); /* This error occurs in open_json and is passed through
+                                               open()*/
     builder.need_kvs_flag(false);
     result_build = builder.build();
     EXPECT_TRUE(result_build);
-    EXPECT_EQ(result_build.value().filename_prefix.CStr(), "./kvsbuilder/kvs_"+std::to_string(instance_id.id));
+    EXPECT_EQ(result_build.value().filename_prefix.CStr(),
+              "./kvsbuilder/kvs_" + std::to_string(instance_id.id));
 }
 
 TEST(kvs_kvsbuilder, kvsbuilder_directory_check) {
-
     /* Test the KvsBuilder with all configurations for the current working directory */
     KvsBuilder builder(instance_id);
     builder.dir("");
     auto result_build = builder.build();
     EXPECT_TRUE(result_build);
-    EXPECT_EQ(result_build.value().filename_prefix.CStr(), "./kvs_"+std::to_string(instance_id.id));
+    EXPECT_EQ(result_build.value().filename_prefix.CStr(),
+              "./kvs_" + std::to_string(instance_id.id));
 
     builder.dir("./");
     result_build = builder.build();
     EXPECT_TRUE(result_build);
-    EXPECT_EQ(result_build.value().filename_prefix.CStr(), "./kvs_"+std::to_string(instance_id.id));
+    EXPECT_EQ(result_build.value().filename_prefix.CStr(),
+              "./kvs_" + std::to_string(instance_id.id));
 
     builder.dir(".");
     result_build = builder.build();
     EXPECT_TRUE(result_build);
-    EXPECT_EQ(result_build.value().filename_prefix.CStr(), "./kvs_"+std::to_string(instance_id.id));
-
+    EXPECT_EQ(result_build.value().filename_prefix.CStr(),
+              "./kvs_" + std::to_string(instance_id.id));
 }

--- a/src/cpp/tests/test_kvs_error.cpp
+++ b/src/cpp/tests/test_kvs_error.cpp
@@ -12,33 +12,32 @@
  ********************************************************************************/
 #include "test_kvs_general.hpp"
 
-
 TEST(kvs_MessageFor, MessageFor) {
-   struct {
+    struct {
         ErrorCode code;
         std::string_view expected_message;
     } test_cases[] = {
-        {ErrorCode::UnmappedError,          "Error that was not yet mapped"},
-        {ErrorCode::FileNotFound,           "File not found"},
-        {ErrorCode::KvsFileReadError,       "KVS file read error"},
-        {ErrorCode::KvsHashFileReadError,   "KVS hash file read error"},
-        {ErrorCode::JsonParserError,        "JSON parser error"},
-        {ErrorCode::JsonGeneratorError,     "JSON generator error"},
+        {ErrorCode::UnmappedError, "Error that was not yet mapped"},
+        {ErrorCode::FileNotFound, "File not found"},
+        {ErrorCode::KvsFileReadError, "KVS file read error"},
+        {ErrorCode::KvsHashFileReadError, "KVS hash file read error"},
+        {ErrorCode::JsonParserError, "JSON parser error"},
+        {ErrorCode::JsonGeneratorError, "JSON generator error"},
         {ErrorCode::PhysicalStorageFailure, "Physical storage failure"},
-        {ErrorCode::IntegrityCorrupted,     "Integrity corrupted"},
-        {ErrorCode::ValidationFailed,       "Validation failed"},
-        {ErrorCode::EncryptionFailed,       "Encryption failed"},
-        {ErrorCode::ResourceBusy,           "Resource is busy"},
-        {ErrorCode::OutOfStorageSpace,      "Out of storage space"},
-        {ErrorCode::QuotaExceeded,          "Quota exceeded"},
-        {ErrorCode::AuthenticationFailed,   "Authentication failed"},
-        {ErrorCode::KeyNotFound,            "Key not found"},
-        {ErrorCode::KeyDefaultNotFound,     "Key default value not found"},
-        {ErrorCode::SerializationFailed,    "Serialization failed"},
-        {ErrorCode::InvalidSnapshotId,      "Invalid snapshot ID"},
-        {ErrorCode::ConversionFailed,       "Conversion failed"},
-        {ErrorCode::MutexLockFailed,        "Mutex failed"},
-        {ErrorCode::InvalidValueType,       "Invalid value type"},
+        {ErrorCode::IntegrityCorrupted, "Integrity corrupted"},
+        {ErrorCode::ValidationFailed, "Validation failed"},
+        {ErrorCode::EncryptionFailed, "Encryption failed"},
+        {ErrorCode::ResourceBusy, "Resource is busy"},
+        {ErrorCode::OutOfStorageSpace, "Out of storage space"},
+        {ErrorCode::QuotaExceeded, "Quota exceeded"},
+        {ErrorCode::AuthenticationFailed, "Authentication failed"},
+        {ErrorCode::KeyNotFound, "Key not found"},
+        {ErrorCode::KeyDefaultNotFound, "Key default value not found"},
+        {ErrorCode::SerializationFailed, "Serialization failed"},
+        {ErrorCode::InvalidSnapshotId, "Invalid snapshot ID"},
+        {ErrorCode::ConversionFailed, "Conversion failed"},
+        {ErrorCode::MutexLockFailed, "Mutex failed"},
+        {ErrorCode::InvalidValueType, "Invalid value type"},
     };
     for (const auto& test : test_cases) {
         SCOPED_TRACE(static_cast<int>(test.code));
@@ -48,5 +47,4 @@ TEST(kvs_MessageFor, MessageFor) {
 
     score::result::ErrorCode invalid_code = static_cast<score::result::ErrorCode>(9999);
     EXPECT_EQ(my_error_domain.MessageFor(invalid_code), "Unknown Error!");
-
 }

--- a/src/cpp/tests/test_kvs_general.cpp
+++ b/src/cpp/tests/test_kvs_general.cpp
@@ -24,7 +24,7 @@ uint32_t adler32(const std::string& data) {
 }
 
 /* Create Test environment with default data, which is needed in most testcases */
-void prepare_environment(){
+void prepare_environment() {
     /* Prepare the test environment */
     mkdir(data_dir.c_str(), 0777);
 
@@ -42,14 +42,14 @@ void prepare_environment(){
     std::ofstream default_hash_file(default_prefix + ".hash", std::ios::binary);
     default_hash_file.put((default_hash >> 24) & 0xFF);
     default_hash_file.put((default_hash >> 16) & 0xFF);
-    default_hash_file.put((default_hash >> 8)  & 0xFF);
+    default_hash_file.put((default_hash >> 8) & 0xFF);
     default_hash_file.put(default_hash & 0xFF);
     default_hash_file.close();
 
     std::ofstream kvs_hash_file(kvs_prefix + ".hash", std::ios::binary);
     kvs_hash_file.put((kvs_hash >> 24) & 0xFF);
     kvs_hash_file.put((kvs_hash >> 16) & 0xFF);
-    kvs_hash_file.put((kvs_hash >> 8)  & 0xFF);
+    kvs_hash_file.put((kvs_hash >> 8) & 0xFF);
     kvs_hash_file.put(kvs_hash & 0xFF);
     kvs_hash_file.close();
 }
@@ -59,8 +59,10 @@ void cleanup_environment() {
     if (std::filesystem::exists(data_dir)) {
         for (auto& p : std::filesystem::recursive_directory_iterator(data_dir)) {
             std::filesystem::permissions(p,
-                std::filesystem::perms::owner_all | std::filesystem::perms::group_all | std::filesystem::perms::others_all,
-                std::filesystem::perm_options::replace);
+                                         std::filesystem::perms::owner_all |
+                                             std::filesystem::perms::group_all |
+                                             std::filesystem::perms::others_all,
+                                         std::filesystem::perm_options::replace);
         }
         std::filesystem::remove_all(data_dir);
     }

--- a/src/cpp/tests/test_kvs_general.hpp
+++ b/src/cpp/tests/test_kvs_general.hpp
@@ -15,25 +15,26 @@
 /* The test_kvs_general files provide configuration data and methods needed for KVS tests */
 ////////////////////////////////////////////////////////////////////////////////
 
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <unistd.h>
 #include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
-#include <gtest/gtest.h>
-#include <gmock/gmock.h>
 #include <string>
-#include <unistd.h>
 
-/* Change Private Members and final to public to allow access to member variables (kvs and kvsbuilder) and derive from kvsvalue in unittests*/
+/* Change Private Members and final to public to allow access to member variables (kvs and
+ * kvsbuilder) and derive from kvsvalue in unittests*/
 #define private public
 #define final
 #include "kvsbuilder.hpp"
 #undef private
 #undef final
 #include "internal/kvs_helper.hpp"
+#include "score/filesystem/filesystem_mock.h"
 #include "score/json/i_json_parser_mock.h"
 #include "score/json/i_json_writer_mock.h"
-#include "score/filesystem/filesystem_mock.h"
 using namespace score::mw::per::kvs;
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -49,12 +50,12 @@ void cleanup_environment();
 const std::uint32_t instance = 123;
 const InstanceId instance_id{instance};
 
-/* Notice: score::filesystem::Path could be constructed implicitly from std::string, but for readability,
-           the explicit construction from those strings are used in the testcode */
+/* Notice: score::filesystem::Path could be constructed implicitly from std::string, but for
+   readability, the explicit construction from those strings are used in the testcode */
 const std::string data_dir = "./data_folder/";
-const std::string default_prefix = data_dir + "kvs_"+std::to_string(instance)+"_default";
-const std::string kvs_prefix     = data_dir + "kvs_"+std::to_string(instance)+"_0";
-const std::string filename_prefix = data_dir + "kvs_"+std::to_string(instance);
+const std::string default_prefix = data_dir + "kvs_" + std::to_string(instance) + "_default";
+const std::string kvs_prefix = data_dir + "kvs_" + std::to_string(instance) + "_0";
+const std::string filename_prefix = data_dir + "kvs_" + std::to_string(instance);
 
 const std::string default_json = R"({
     "default": {
@@ -74,7 +75,7 @@ const std::string kvs_json = R"({
 ////////////////////////////////////////////////////////////////////////////////
 
 class BrokenKvsValue : public KvsValue {
-public:
+   public:
     BrokenKvsValue() : KvsValue(nullptr) {
         /* Intentionally break the type by assigning an invalid value */
         *(Type*)&this->type = static_cast<Type>(999);

--- a/src/cpp/tests/test_kvs_helper.cpp
+++ b/src/cpp/tests/test_kvs_helper.cpp
@@ -12,7 +12,6 @@
  ********************************************************************************/
 #include "test_kvs_general.hpp"
 
-
 TEST(kvs_calculate_hash_adler32, calculate_hash_adler32) {
     /* Test the adler32 hash calculation
     Parsing test is done automatically by the open tests */
@@ -21,22 +20,19 @@ TEST(kvs_calculate_hash_adler32, calculate_hash_adler32) {
     uint32_t calculated_hash = adler32(test_data);
     EXPECT_EQ(calculated_hash, calculate_hash_adler32(test_data));
 
-    std::array<uint8_t,4> buf{};
+    std::array<uint8_t, 4> buf{};
     std::istringstream stream(test_data);
     stream.read(reinterpret_cast<char*>(buf.data()), buf.size());
 
     std::array<uint8_t, 4> value = {
-        uint8_t((calculated_hash >> 24) & 0xFF),
-        uint8_t((calculated_hash >> 16) & 0xFF),
-        uint8_t((calculated_hash >>  8) & 0xFF),
-        uint8_t((calculated_hash      ) & 0xFF)
-    };
+        uint8_t((calculated_hash >> 24) & 0xFF), uint8_t((calculated_hash >> 16) & 0xFF),
+        uint8_t((calculated_hash >> 8) & 0xFF), uint8_t((calculated_hash) & 0xFF)};
     EXPECT_EQ(value, get_hash_bytes(test_data));
-
 }
 
 TEST(kvs_calculate_hash_adler32, calculate_hash_adler32_large_data) {
-    // Create Teststring with more than 5552 characters to ensure that the hash is calculated correctly
+    // Create Teststring with more than 5552 characters to ensure that the hash is calculated
+    // correctly
     std::string large_data(6000, 'A');
     uint32_t hash = calculate_hash_adler32(large_data);
 
@@ -44,15 +40,10 @@ TEST(kvs_calculate_hash_adler32, calculate_hash_adler32_large_data) {
 }
 
 TEST(kvs_check_hash, check_hash_valid) {
-
     std::string test_data = "Hello, World!";
     uint32_t hash = adler32(test_data);
-    std::array<uint8_t, 4> hash_bytes = {
-        uint8_t((hash >> 24) & 0xFF),
-        uint8_t((hash >> 16) & 0xFF),
-        uint8_t((hash >>  8) & 0xFF),
-        uint8_t((hash      ) & 0xFF)
-    };
+    std::array<uint8_t, 4> hash_bytes = {uint8_t((hash >> 24) & 0xFF), uint8_t((hash >> 16) & 0xFF),
+                                         uint8_t((hash >> 8) & 0xFF), uint8_t((hash) & 0xFF)};
     std::string hash_string(reinterpret_cast<const char*>(hash_bytes.data()), hash_bytes.size());
     std::istringstream hash_stream(hash_string);
 
@@ -60,15 +51,10 @@ TEST(kvs_check_hash, check_hash_valid) {
 }
 
 TEST(kvs_check_hash, check_hash_invalid) {
-
     std::string test_data = "Hello, World!";
     uint32_t hash = adler32(test_data);
-    std::array<uint8_t, 4> hash_bytes = {
-        uint8_t((hash >> 24) & 0xFF),
-        uint8_t((hash >> 16) & 0xFF),
-        uint8_t((hash >>  8) & 0xFF),
-        uint8_t((hash      ) & 0xFF)
-    };
+    std::array<uint8_t, 4> hash_bytes = {uint8_t((hash >> 24) & 0xFF), uint8_t((hash >> 16) & 0xFF),
+                                         uint8_t((hash >> 8) & 0xFF), uint8_t((hash) & 0xFF)};
     std::string hash_string(reinterpret_cast<const char*>(hash_bytes.data()), hash_bytes.size());
     std::istringstream hash_stream(hash_string);
 
@@ -233,7 +219,7 @@ TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_no_object) {
 
 TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_type_no_string) {
     score::json::Object obj;
-    obj.emplace("t", score::json::Any(42.0)); // Not a string
+    obj.emplace("t", score::json::Any(42.0));  // Not a string
     obj.emplace("v", score::json::Any(true));
     score::json::Any any_obj(std::move(obj));
     auto result = any_to_kvsvalue(any_obj);
@@ -253,7 +239,7 @@ TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_type_invalid) {
 
 TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_no_string_type) {
     score::json::Object obj;
-    obj.emplace("t", score::json::Any(42.0)); // Not a string
+    obj.emplace("t", score::json::Any(42.0));  // Not a string
     obj.emplace("v", score::json::Any(true));
     score::json::Any any_obj(std::move(obj));
     auto result = any_to_kvsvalue(any_obj);
@@ -261,80 +247,80 @@ TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_no_string_type) {
     EXPECT_EQ(result.error(), ErrorCode::InvalidValueType);
 }
 
-TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_i32){
+TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_i32) {
     score::json::Object obj;
     obj.emplace("t", score::json::Any(std::string("i32")));
-    obj.emplace("v", score::json::Any("invalid")); // Invalid value for I32
+    obj.emplace("v", score::json::Any("invalid"));  // Invalid value for I32
     score::json::Any any_obj(std::move(obj));
     auto result = any_to_kvsvalue(any_obj);
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), ErrorCode::InvalidValueType);
 }
 
-TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_u32){
+TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_u32) {
     score::json::Object obj;
     obj.emplace("t", score::json::Any(std::string("u32")));
-    obj.emplace("v", score::json::Any("invalid")); // Invalid value for U32
+    obj.emplace("v", score::json::Any("invalid"));  // Invalid value for U32
     score::json::Any any_obj(std::move(obj));
     auto result = any_to_kvsvalue(any_obj);
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), ErrorCode::InvalidValueType);
 }
 
-TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_i64){
+TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_i64) {
     score::json::Object obj;
     obj.emplace("t", score::json::Any(std::string("i64")));
-    obj.emplace("v", score::json::Any("invalid")); // Invalid value for I64
+    obj.emplace("v", score::json::Any("invalid"));  // Invalid value for I64
     score::json::Any any_obj(std::move(obj));
     auto result = any_to_kvsvalue(any_obj);
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), ErrorCode::InvalidValueType);
 }
 
-TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_u64){
+TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_u64) {
     score::json::Object obj;
     obj.emplace("t", score::json::Any(std::string("u64")));
-    obj.emplace("v", score::json::Any("invalid")); // Invalid value for U64
+    obj.emplace("v", score::json::Any("invalid"));  // Invalid value for U64
     score::json::Any any_obj(std::move(obj));
     auto result = any_to_kvsvalue(any_obj);
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), ErrorCode::InvalidValueType);
 }
 
-TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_f64){
+TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_f64) {
     score::json::Object obj;
     obj.emplace("t", score::json::Any(std::string("f64")));
-    obj.emplace("v", score::json::Any("invalid")); // Invalid value for F64
+    obj.emplace("v", score::json::Any("invalid"));  // Invalid value for F64
     score::json::Any any_obj(std::move(obj));
     auto result = any_to_kvsvalue(any_obj);
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), ErrorCode::InvalidValueType);
 }
 
-TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_boolean){
+TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_boolean) {
     score::json::Object obj;
     obj.emplace("t", score::json::Any(std::string("bool")));
-    obj.emplace("v", score::json::Any(42.0)); // Invalid value for Boolean
+    obj.emplace("v", score::json::Any(42.0));  // Invalid value for Boolean
     score::json::Any any_obj(std::move(obj));
     auto result = any_to_kvsvalue(any_obj);
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), ErrorCode::InvalidValueType);
 }
 
-TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_string){
+TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_string) {
     score::json::Object obj;
     obj.emplace("t", score::json::Any(std::string("str")));
-    obj.emplace("v", score::json::Any(42.0)); // Invalid value for String
+    obj.emplace("v", score::json::Any(42.0));  // Invalid value for String
     score::json::Any any_obj(std::move(obj));
     auto result = any_to_kvsvalue(any_obj);
     EXPECT_FALSE(result.has_value());
     EXPECT_EQ(result.error(), ErrorCode::InvalidValueType);
 }
 
-TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_null){
+TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_null) {
     score::json::Object obj;
     obj.emplace("t", score::json::Any(std::string("null")));
-    obj.emplace("v", score::json::Any(42.0)); // Invalid value for Null
+    obj.emplace("v", score::json::Any(42.0));  // Invalid value for Null
     score::json::Any any_obj(std::move(obj));
     auto result = any_to_kvsvalue(any_obj);
     EXPECT_FALSE(result.has_value());
@@ -344,7 +330,7 @@ TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_null){
 TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_array) {
     score::json::Object obj;
     obj.emplace("t", score::json::Any(std::string("arr")));
-    obj.emplace("v", score::json::Any(42.0)); // Invalid value for Array
+    obj.emplace("v", score::json::Any(42.0));  // Invalid value for Array
     score::json::Any any_obj(std::move(obj));
     auto result = any_to_kvsvalue(any_obj);
     EXPECT_FALSE(result.has_value());
@@ -354,7 +340,7 @@ TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_array) {
 TEST(kvs_any_to_kvsvalue, any_to_kvsvalue_invalid_object) {
     score::json::Object obj;
     obj.emplace("t", score::json::Any(std::string("obj")));
-    obj.emplace("v", score::json::Any(42.0)); // Invalid value for Object
+    obj.emplace("v", score::json::Any(42.0));  // Invalid value for Object
     score::json::Any any_obj(std::move(obj));
     auto result = any_to_kvsvalue(any_obj);
     EXPECT_FALSE(result.has_value());
@@ -507,8 +493,8 @@ TEST(kvs_kvsvalue_to_any, kvsvalue_to_any_array) {
 
 TEST(kvs_kvsvalue_to_any, kvsvalue_to_any_object) {
     KvsValue::Object obj;
-    obj.emplace("flag", std::make_shared<KvsValue>(true)); // Boolean
-    obj.emplace("count", std::make_shared<KvsValue>(42.0)); // F64
+    obj.emplace("flag", std::make_shared<KvsValue>(true));   // Boolean
+    obj.emplace("count", std::make_shared<KvsValue>(42.0));  // F64
     KvsValue obj_val(obj);
 
     auto result = kvsvalue_to_any(obj_val);

--- a/tests/cpp_test_scenarios/src/cit/cit.cpp
+++ b/tests/cpp_test_scenarios/src/cit/cit.cpp
@@ -19,7 +19,6 @@
 
 ScenarioGroup::Ptr cit_scenario_group()
 {
-    return ScenarioGroup::Ptr{
-        new ScenarioGroupImpl{
-            "cit", {}, {default_values_group(), multiple_kvs_group(), snapshots_group(), supported_datatypes_group()}}};
+    return ScenarioGroup::Ptr{new ScenarioGroupImpl{
+        "cit", {}, {default_values_group(), multiple_kvs_group(), snapshots_group(), supported_datatypes_group()}}};
 }

--- a/tests/cpp_test_scenarios/src/cit/default_values.cpp
+++ b/tests/cpp_test_scenarios/src/cit/default_values.cpp
@@ -12,15 +12,16 @@
  ********************************************************************************/
 
 #include "default_values.hpp"
-#include <sstream>
 #include "helpers/helpers.hpp"
 #include "helpers/kvs_instance.hpp"
 #include "helpers/kvs_parameters.hpp"
 #include "tracing.hpp"
+#include <sstream>
 
 using namespace score::mw::per::kvs;
 
-namespace {
+namespace
+{
 const std::string kTargetName{"cpp_test_scenarios::cit::default_values"};
 
 /**
@@ -37,9 +38,13 @@ const std::string kTargetName{"cpp_test_scenarios::cit::default_values"};
  * This function emits logs in a structured format so that the Python test suite
  * can parse and validate scenario output.
  */
-static void info_log(const std::string& key, const std::string& value_is_default,
-                     const std::string& default_value, const std::string& current_value) {
-    TRACING_INFO(kTargetName, std::pair{std::string{"key"}, key},
+static void info_log(const std::string& key,
+                     const std::string& value_is_default,
+                     const std::string& default_value,
+                     const std::string& current_value)
+{
+    TRACING_INFO(kTargetName,
+                 std::pair{std::string{"key"}, key},
                  std::pair{std::string{"value_is_default"}, value_is_default},
                  std::pair{std::string{"default_value"}, default_value},
                  std::pair{std::string{"current_value"}, current_value});
@@ -58,58 +63,80 @@ static void info_log(const std::string& key, const std::string& value_is_default
  * logs the current value as a typed parameter and omits the default value.
  */
 template <typename T>
-static void info_log(const std::string& key, const bool value_is_default, T current_value) {
-    TRACING_INFO(kTargetName, std::pair{std::string{"key"}, key},
+static void info_log(const std::string& key, const bool value_is_default, T current_value)
+{
+    TRACING_INFO(kTargetName,
+                 std::pair{std::string{"key"}, key},
                  std::pair{std::string{"value_is_default"}, value_is_default},
                  std::pair{std::string{"current_value"}, current_value});
 }
 
 // TODO: `has_default_value` should be `const` operation.
-std::string get_value_is_default(Kvs& kvs, const std::string& key) {
+std::string get_value_is_default(Kvs& kvs, const std::string& key)
+{
     auto result{kvs.has_default_value(key)};
-    if (result.has_value()) {
-        if (result.value()) {
+    if (result.has_value())
+    {
+        if (result.value())
+        {
             return std::string{"Ok(true)"};
-        } else {
+        }
+        else
+        {
             return std::string{"Ok(false)"};
         }
-    } else {
+    }
+    else
+    {
         return std::string{"Err(KeyNotFound)"};
     }
 }
 
-std::string get_default_value(Kvs& kvs, const std::string& key) {
+std::string get_default_value(Kvs& kvs, const std::string& key)
+{
     auto result{kvs.get_default_value(key)};
-    if (result.has_value() && result.value().getType() == KvsValue::Type::f64) {
+    if (result.has_value() && result.value().getType() == KvsValue::Type::f64)
+    {
         std::ostringstream oss;
         oss.precision(1);
         oss << std::fixed << std::get<double>(result.value().getValue());
         return std::string{"Ok(F64(" + oss.str() + "))"};
-    } else {
+    }
+    else
+    {
         return std::string{"Err(KeyNotFound)"};
     }
 }
 
-std::string get_current_value(Kvs& kvs, const std::string& key) {
+std::string get_current_value(Kvs& kvs, const std::string& key)
+{
     auto result{kvs.get_value(key)};
-    if (result.has_value() && result.value().getType() == KvsValue::Type::f64) {
+    if (result.has_value() && result.value().getType() == KvsValue::Type::f64)
+    {
         std::ostringstream oss;
         oss.precision(1);
         oss << std::fixed << std::get<double>(result.value().getValue());
         return std::string{"Ok(F64(" + oss.str() + "))"};
-    } else {
+    }
+    else
+    {
         return std::string{"Err(KeyNotFound)"};
     }
 }
 }  // namespace
 
-class DefaultValues final : public Scenario {
-   public:
+class DefaultValues final : public Scenario
+{
+  public:
     ~DefaultValues() final = default;
 
-    std::string name() const final { return "default_values"; }
+    std::string name() const final
+    {
+        return "default_values";
+    }
 
-    void run(const std::string& input) const final {
+    void run(const std::string& input) const final
+    {
         // Key used for tests.
         std::string key{"test_number"};
 
@@ -127,13 +154,15 @@ class DefaultValues final : public Scenario {
 
             // Set value and check value parameters.
             auto set_result{kvs.set_value(key, KvsValue{432.1})};
-            if (!set_result) {
+            if (!set_result)
+            {
                 throw std::runtime_error{"Failed to set value"};
             }
 
             // Flush KVS.
             auto flush_result{kvs.flush()};
-            if (!flush_result) {
+            if (!flush_result)
+            {
                 throw std::runtime_error{"Failed to flush"};
             }
         }
@@ -152,13 +181,18 @@ class DefaultValues final : public Scenario {
     }
 };
 
-class RemoveKey final : public Scenario {
-   public:
+class RemoveKey final : public Scenario
+{
+  public:
     ~RemoveKey() final = default;
 
-    std::string name() const final { return "remove_key"; }
+    std::string name() const final
+    {
+        return "remove_key";
+    }
 
-    void run(const std::string& input) const final {
+    void run(const std::string& input) const final
+    {
         // Key used for tests.
         std::string key{"test_number"};
 
@@ -177,7 +211,8 @@ class RemoveKey final : public Scenario {
 
         // Get value parameters after set.
         auto set_result{kvs.set_value(key, KvsValue{432.1})};
-        if (!set_result) {
+        if (!set_result)
+        {
             throw std::runtime_error{"Failed to set value"};
         }
 
@@ -193,7 +228,8 @@ class RemoveKey final : public Scenario {
         // Get value parameters after remove.
         {
             auto remove_result{kvs.remove_key(key)};
-            if (!remove_result) {
+            if (!remove_result)
+            {
                 throw std::runtime_error{"Failed to remove key"};
             }
 
@@ -206,13 +242,18 @@ class RemoveKey final : public Scenario {
     }
 };
 
-class ResetAllKeys final : public Scenario {
-   public:
+class ResetAllKeys final : public Scenario
+{
+  public:
     ~ResetAllKeys() final = default;
 
-    std::string name() const final { return "reset_all_keys"; }
+    std::string name() const final
+    {
+        return "reset_all_keys";
+    }
 
-    void run(const std::string& input) const final {
+    void run(const std::string& input) const final
+    {
         const int num_values{5};
 
         // Create KVS instance with provided params.
@@ -221,12 +262,14 @@ class ResetAllKeys final : public Scenario {
 
         // List of keys and corresponding values.
         std::vector<std::pair<std::string, double>> key_values;
-        for (int i{0}; i < num_values; ++i) {
+        for (int i{0}; i < num_values; ++i)
+        {
             key_values.emplace_back("test_number_" + std::to_string(i), 123.4 * i);
         }
 
         // Set non-default values.
-        for (const auto& [key, value] : key_values) {
+        for (const auto& [key, value] : key_values)
+        {
             // Get value before set.
             {
                 const bool value_is_default{kvs.has_default_value(key).value()};
@@ -237,7 +280,8 @@ class ResetAllKeys final : public Scenario {
 
             // Set value.
             auto set_result{kvs.set_value(key, KvsValue{value})};
-            if (!set_result) {
+            if (!set_result)
+            {
                 throw std::runtime_error{"Failed to set value"};
             }
 
@@ -252,12 +296,14 @@ class ResetAllKeys final : public Scenario {
 
         // Reset.
         auto reset_result{kvs.reset()};
-        if (!reset_result) {
+        if (!reset_result)
+        {
             throw std::runtime_error{"Failed to reset KVS instance"};
         }
 
         // Get value parameters after reset.
-        for (const auto& [key, _] : key_values) {
+        for (const auto& [key, _] : key_values)
+        {
             const bool value_is_default{kvs.has_default_value(key).value()};
             const double current_value{std::get<double>((*kvs.get_value(key)).getValue())};
 
@@ -266,13 +312,18 @@ class ResetAllKeys final : public Scenario {
     }
 };
 
-class ResetSingleKey final : public Scenario {
-   public:
+class ResetSingleKey final : public Scenario
+{
+  public:
     ~ResetSingleKey() final = default;
 
-    std::string name() const final { return "reset_single_key"; }
+    std::string name() const final
+    {
+        return "reset_single_key";
+    }
 
-    void run(const std::string& input) const final {
+    void run(const std::string& input) const final
+    {
         const int num_values{5};
         const int reset_index{2};
 
@@ -282,12 +333,14 @@ class ResetSingleKey final : public Scenario {
 
         // List of keys and corresponding values.
         std::vector<std::pair<std::string, double>> key_values;
-        for (int i{0}; i < num_values; ++i) {
+        for (int i{0}; i < num_values; ++i)
+        {
             key_values.emplace_back("test_number_" + std::to_string(i), 123.4 * i);
         }
 
         // Set non-default values.
-        for (const auto& [key, value] : key_values) {
+        for (const auto& [key, value] : key_values)
+        {
             // Get value parameters before set.
             {
                 const bool value_is_default{kvs.has_default_value(key).value()};
@@ -298,7 +351,8 @@ class ResetSingleKey final : public Scenario {
 
             // Set value.
             auto set_result{kvs.set_value(key, KvsValue{value})};
-            if (!set_result) {
+            if (!set_result)
+            {
                 throw std::runtime_error{"Failed to set value"};
             }
 
@@ -313,12 +367,14 @@ class ResetSingleKey final : public Scenario {
 
         // Reset single key.
         auto reset_result{kvs.reset_key(key_values[reset_index].first)};
-        if (!reset_result) {
+        if (!reset_result)
+        {
             throw std::runtime_error{"Failed to reset key"};
         }
 
         // Use KVS APIs to get value_is_default and current_value after reset
-        for (const auto& [key, value] : key_values) {
+        for (const auto& [key, value] : key_values)
+        {
             const bool value_is_default{kvs.has_default_value(key).value()};
             const double current_value{std::get<double>((*kvs.get_value(key)).getValue())};
             info_log(key, value_is_default, current_value);
@@ -326,13 +382,18 @@ class ResetSingleKey final : public Scenario {
     }
 };
 
-class Checksum final : public Scenario {
-   public:
+class Checksum final : public Scenario
+{
+  public:
     ~Checksum() final = default;
 
-    std::string name() const final { return "checksum"; }
+    std::string name() const final
+    {
+        return "checksum";
+    }
 
-    void run(const std::string& input) const final {
+    void run(const std::string& input) const final
+    {
         // Create KVS instance with provided params.
         auto params{KvsParameters::from_json(input)};
         auto working_dir{*params.dir};
@@ -341,24 +402,26 @@ class Checksum final : public Scenario {
             // Create instance, flush, store paths to files, close instance.
             auto kvs{kvs_instance(params)};
             auto flush_result{kvs.flush()};
-            if (!flush_result) {
+            if (!flush_result)
+            {
                 throw std::runtime_error{"Failed to flush"};
             }
-            std::tie(kvs_path, hash_path) =
-                kvs_hash_paths(working_dir, params.instance_id, SnapshotId{0});
+            std::tie(kvs_path, hash_path) = kvs_hash_paths(working_dir, params.instance_id, SnapshotId{0});
         }
 
-        TRACING_INFO(kTargetName, std::pair{std::string{"kvs_path"}, kvs_path},
-                     std::pair{std::string{"hash_path"}, hash_path});
+        TRACING_INFO(
+            kTargetName, std::pair{std::string{"kvs_path"}, kvs_path}, std::pair{std::string{"hash_path"}, hash_path});
     }
 };
 
 // Default values group
-ScenarioGroup::Ptr default_values_group() {
-    return ScenarioGroup::Ptr{
-        new ScenarioGroupImpl{"default_values",
-                              {std::make_shared<DefaultValues>(), std::make_shared<RemoveKey>(),
-                               std::make_shared<ResetAllKeys>(), std::make_shared<ResetSingleKey>(),
-                               std::make_shared<Checksum>()},
-                              {}}};
+ScenarioGroup::Ptr default_values_group()
+{
+    return ScenarioGroup::Ptr{new ScenarioGroupImpl{"default_values",
+                                                    {std::make_shared<DefaultValues>(),
+                                                     std::make_shared<RemoveKey>(),
+                                                     std::make_shared<ResetAllKeys>(),
+                                                     std::make_shared<ResetSingleKey>(),
+                                                     std::make_shared<Checksum>()},
+                                                    {}}};
 }

--- a/tests/cpp_test_scenarios/src/cit/multiple_kvs.cpp
+++ b/tests/cpp_test_scenarios/src/cit/multiple_kvs.cpp
@@ -12,32 +12,41 @@
  ********************************************************************************/
 
 #include "multiple_kvs.hpp"
-#include <cmath>
-#include <iomanip>
-#include <sstream>
 #include "helpers/kvs_instance.hpp"
 #include "helpers/kvs_parameters.hpp"
 #include "tracing.hpp"
+#include <cmath>
+#include <iomanip>
+#include <sstream>
 
 using namespace score::mw::per::kvs;
 using namespace score::json;
 
-namespace {
+namespace
+{
 const std::string kTargetName{"cpp_test_scenarios::multiple_kvs"};
 
-static void info_log(const std::string& instance, const std::string& keyname, double value) {
-    TRACING_INFO(kTargetName, std::pair{std::string{"instance"}, instance},
-                 std::pair{std::string{"key"}, keyname}, std::pair{std::string{"value"}, value});
+static void info_log(const std::string& instance, const std::string& keyname, double value)
+{
+    TRACING_INFO(kTargetName,
+                 std::pair{std::string{"instance"}, instance},
+                 std::pair{std::string{"key"}, keyname},
+                 std::pair{std::string{"value"}, value});
 }
 }  // namespace
 
-class MultipleInstanceIds : public Scenario {
-   public:
+class MultipleInstanceIds : public Scenario
+{
+  public:
     ~MultipleInstanceIds() final = default;
 
-    std::string name() const final { return "multiple_instance_ids"; }
+    std::string name() const final
+    {
+        return "multiple_instance_ids";
+    }
 
-    void run(const std::string& input) const final {
+    void run(const std::string& input) const final
+    {
         // Values.
         const std::string keyname{"number"};
         const double value1{111.1};
@@ -46,15 +55,14 @@ class MultipleInstanceIds : public Scenario {
         // Parameters.
         JsonParser parser;
         auto any_res{parser.FromBuffer(input)};
-        if (!any_res) {
+        if (!any_res)
+        {
             throw any_res.error();
         }
         auto& obj{any_res.value().As<Object>().value().get()};
 
-        auto params1{
-            KvsParameters::from_object(obj.at("kvs_parameters_1").As<Object>().value().get())};
-        auto params2{
-            KvsParameters::from_object(obj.at("kvs_parameters_2").As<Object>().value().get())};
+        auto params1{KvsParameters::from_object(obj.at("kvs_parameters_1").As<Object>().value().get())};
+        auto params2{KvsParameters::from_object(obj.at("kvs_parameters_2").As<Object>().value().get())};
         {
             // Create first KVS instance.
             auto kvs1{kvs_instance(params1)};
@@ -64,21 +72,25 @@ class MultipleInstanceIds : public Scenario {
 
             // Set value to both KVS instances.
             auto set_result_1{kvs1.set_value(keyname, KvsValue{value1})};
-            if (!set_result_1) {
+            if (!set_result_1)
+            {
                 throw std::runtime_error{"Failed to set value"};
             }
             auto set_result_2{kvs2.set_value(keyname, KvsValue{value2})};
-            if (!set_result_2) {
+            if (!set_result_2)
+            {
                 throw std::runtime_error{"Failed to set value"};
             }
 
             // Flush KVS.
             auto flush_result_1{kvs1.flush()};
-            if (!flush_result_1) {
+            if (!flush_result_1)
+            {
                 throw std::runtime_error{"Failed to flush first instance"};
             }
             auto flush_result_2{kvs2.flush()};
-            if (!flush_result_2) {
+            if (!flush_result_2)
+            {
                 throw std::runtime_error{"Failed to flush second instance"};
             }
         }
@@ -89,13 +101,15 @@ class MultipleInstanceIds : public Scenario {
             auto kvs2{kvs_instance(params2)};
 
             auto value1{kvs1.get_value(keyname)};
-            if (!value1) {
+            if (!value1)
+            {
                 throw std::runtime_error{"Failed to read value"};
             }
             info_log("kvs1", keyname, std::get<double>(value1->getValue()));
 
             auto value2{kvs2.get_value(keyname)};
-            if (!value2) {
+            if (!value2)
+            {
                 throw std::runtime_error{"Failed to read value"};
             }
             info_log("kvs2", keyname, std::get<double>(value2->getValue()));
@@ -103,13 +117,18 @@ class MultipleInstanceIds : public Scenario {
     }
 };
 
-class SameInstanceIdSameValue : public Scenario {
-   public:
+class SameInstanceIdSameValue : public Scenario
+{
+  public:
     ~SameInstanceIdSameValue() final = default;
 
-    std::string name() const final { return "same_instance_id_same_value"; }
+    std::string name() const final
+    {
+        return "same_instance_id_same_value";
+    }
 
-    void run(const std::string& input) const final {
+    void run(const std::string& input) const final
+    {
         // Values.
         const std::string keyname{"number"};
         const double value{111.1};
@@ -125,21 +144,25 @@ class SameInstanceIdSameValue : public Scenario {
 
             // Set value to both KVS instances.
             auto set_result_1{kvs1.set_value(keyname, KvsValue{value})};
-            if (!set_result_1) {
+            if (!set_result_1)
+            {
                 throw std::runtime_error{"Failed to set value"};
             }
             auto set_result_2{kvs2.set_value(keyname, KvsValue{value})};
-            if (!set_result_2) {
+            if (!set_result_2)
+            {
                 throw std::runtime_error{"Failed to set value"};
             }
 
             // Flush KVS.
             auto flush_result_1{kvs1.flush()};
-            if (!flush_result_1) {
+            if (!flush_result_1)
+            {
                 throw std::runtime_error{"Failed to flush first instance"};
             }
             auto flush_result_2{kvs2.flush()};
-            if (!flush_result_2) {
+            if (!flush_result_2)
+            {
                 throw std::runtime_error{"Failed to flush second instance"};
             }
         }
@@ -150,13 +173,15 @@ class SameInstanceIdSameValue : public Scenario {
             auto kvs2{kvs_instance(params)};
 
             auto value1{kvs1.get_value(keyname)};
-            if (!value1) {
+            if (!value1)
+            {
                 throw std::runtime_error{"Failed to read value"};
             }
             info_log("kvs1", keyname, std::get<double>(value1->getValue()));
 
             auto value2{kvs2.get_value(keyname)};
-            if (!value2) {
+            if (!value2)
+            {
                 throw std::runtime_error{"Failed to read value"};
             }
             info_log("kvs2", keyname, std::get<double>(value2->getValue()));
@@ -164,13 +189,18 @@ class SameInstanceIdSameValue : public Scenario {
     }
 };
 
-class SameInstanceIdDifferentValue : public Scenario {
-   public:
+class SameInstanceIdDifferentValue : public Scenario
+{
+  public:
     ~SameInstanceIdDifferentValue() final = default;
 
-    std::string name() const final { return "same_instance_id_diff_value"; }
+    std::string name() const final
+    {
+        return "same_instance_id_diff_value";
+    }
 
-    void run(const std::string& input) const final {
+    void run(const std::string& input) const final
+    {
         // Values.
         const std::string keyname{"number"};
         const double value1{111.1};
@@ -187,21 +217,25 @@ class SameInstanceIdDifferentValue : public Scenario {
 
             // Set value to both KVS instances.
             auto set_result_1{kvs1.set_value(keyname, KvsValue{value1})};
-            if (!set_result_1) {
+            if (!set_result_1)
+            {
                 throw std::runtime_error{"Failed to set value"};
             }
             auto set_result_2{kvs2.set_value(keyname, KvsValue{value2})};
-            if (!set_result_2) {
+            if (!set_result_2)
+            {
                 throw std::runtime_error{"Failed to set value"};
             }
 
             // Flush KVS.
             auto flush_result_1{kvs1.flush()};
-            if (!flush_result_1) {
+            if (!flush_result_1)
+            {
                 throw std::runtime_error{"Failed to flush first instance"};
             }
             auto flush_result_2{kvs2.flush()};
-            if (!flush_result_2) {
+            if (!flush_result_2)
+            {
                 throw std::runtime_error{"Failed to flush second instance"};
             }
         }
@@ -212,13 +246,15 @@ class SameInstanceIdDifferentValue : public Scenario {
             auto kvs2{kvs_instance(params)};
 
             auto value1{kvs1.get_value(keyname)};
-            if (!value1) {
+            if (!value1)
+            {
                 throw std::runtime_error{"Failed to read value"};
             }
             info_log("kvs1", keyname, std::get<double>(value1->getValue()));
 
             auto value2{kvs2.get_value(keyname)};
-            if (!value2) {
+            if (!value2)
+            {
                 throw std::runtime_error{"Failed to read value"};
             }
             info_log("kvs2", keyname, std::get<double>(value2->getValue()));
@@ -226,13 +262,13 @@ class SameInstanceIdDifferentValue : public Scenario {
     }
 };
 
-ScenarioGroup::Ptr multiple_kvs_group() {
-    return ScenarioGroup::Ptr{
-        new ScenarioGroupImpl{"multiple_kvs",
-                              {
-                                  std::make_shared<MultipleInstanceIds>(),
-                                  std::make_shared<SameInstanceIdSameValue>(),
-                                  std::make_shared<SameInstanceIdDifferentValue>(),
-                              },
-                              {}}};
+ScenarioGroup::Ptr multiple_kvs_group()
+{
+    return ScenarioGroup::Ptr{new ScenarioGroupImpl{"multiple_kvs",
+                                                    {
+                                                        std::make_shared<MultipleInstanceIds>(),
+                                                        std::make_shared<SameInstanceIdSameValue>(),
+                                                        std::make_shared<SameInstanceIdDifferentValue>(),
+                                                    },
+                                                    {}}};
 }

--- a/tests/cpp_test_scenarios/src/cit/snapshots.cpp
+++ b/tests/cpp_test_scenarios/src/cit/snapshots.cpp
@@ -20,27 +20,33 @@
 using namespace score::mw::per::kvs;
 using namespace score::json;
 
-namespace {
+namespace
+{
 const std::string kTargetName{"cpp_test_scenarios::snapshots::count"};
 
 template <typename T>
-T get_field(const Object& obj, const std::string& field) {
+T get_field(const Object& obj, const std::string& field)
+{
     auto it{obj.find(field)};
-    if (it == obj.end()) {
+    if (it == obj.end())
+    {
         throw std::runtime_error("Missing field: " + field);
     }
     return it->second.As<T>().value();
 }
 
-Object get_object(const std::string& data) {
+Object get_object(const std::string& data)
+{
     JsonParser parser;
     auto from_buffer_result{parser.FromBuffer(data)};
-    if (!from_buffer_result) {
+    if (!from_buffer_result)
+    {
         throw std::runtime_error{"Failed to parse JSON"};
     }
 
     auto as_object_result{from_buffer_result.value().As<Object>()};
-    if (!as_object_result) {
+    if (!as_object_result)
+    {
         throw std::runtime_error{"Failed to cast JSON to object"};
     }
 
@@ -48,11 +54,15 @@ Object get_object(const std::string& data) {
 }
 }  // namespace
 
-class SnapshotCount : public Scenario {
-   public:
+class SnapshotCount : public Scenario
+{
+  public:
     ~SnapshotCount() final = default;
 
-    std::string name() const final { return "count"; }
+    std::string name() const final
+    {
+        return "count";
+    }
 
     /**
      * Requirement not being met:
@@ -77,30 +87,34 @@ class SnapshotCount : public Scenario {
      * Raised bugs: https://github.com/eclipse-score/persistency/issues/108
      *              https://github.com/eclipse-score/persistency/issues/192
      */
-    void run(const std::string& input) const final {
+    void run(const std::string& input) const final
+    {
         auto obj{get_object(input)};
         auto count{get_field<int32_t>(obj, "count")};
         auto params{KvsParameters::from_json(input)};
 
         // Create snapshots.
-        for (int32_t i{0}; i < count; ++i) {
+        for (int32_t i{0}; i < count; ++i)
+        {
             auto kvs{kvs_instance(params)};
             auto set_result{kvs.set_value("counter", KvsValue{i})};
-            if (!set_result) {
+            if (!set_result)
+            {
                 throw std::runtime_error{"Failed to set value"};
             }
 
             auto count_result{kvs.snapshot_count()};
-            if (!count_result) {
+            if (!count_result)
+            {
                 throw std::runtime_error{"Unable to get snapshot count"};
             }
 
-            TRACING_INFO(kTargetName,
-                         std::pair{std::string{"snapshot_count"}, count_result.value()});
+            TRACING_INFO(kTargetName, std::pair{std::string{"snapshot_count"}, count_result.value()});
 
             // Flush KVS.
             auto flush_result{kvs.flush()};
-            if (!flush_result) {
+            if (!flush_result)
+            {
                 throw std::runtime_error{"Failed to flush"};
             }
         }
@@ -108,22 +122,27 @@ class SnapshotCount : public Scenario {
         {
             auto kvs{kvs_instance(params)};
             auto count_result{kvs.snapshot_count()};
-            if (!count_result) {
+            if (!count_result)
+            {
                 throw std::runtime_error{"Unable to get snapshot count"};
             }
-            TRACING_INFO(kTargetName,
-                         std::pair{std::string{"snapshot_count"}, count_result.value()});
+            TRACING_INFO(kTargetName, std::pair{std::string{"snapshot_count"}, count_result.value()});
         }
     }
 };
 
-class SnapshotMaxCount : public Scenario {
-   public:
+class SnapshotMaxCount : public Scenario
+{
+  public:
     ~SnapshotMaxCount() final = default;
 
-    std::string name() const final { return "max_count"; }
+    std::string name() const final
+    {
+        return "max_count";
+    }
 
-    void run(const std::string& input) const final {
+    void run(const std::string& input) const final
+    {
         auto obj{get_object(input)};
         auto count{get_field<int32_t>(obj, "count")};
         auto params{KvsParameters::from_json(input)};
@@ -133,29 +152,37 @@ class SnapshotMaxCount : public Scenario {
     }
 };
 
-class SnapshotRestore : public Scenario {
-   public:
+class SnapshotRestore : public Scenario
+{
+  public:
     ~SnapshotRestore() final = default;
 
-    std::string name() const final { return "restore"; }
+    std::string name() const final
+    {
+        return "restore";
+    }
 
-    void run(const std::string& input) const final {
+    void run(const std::string& input) const final
+    {
         auto obj{get_object(input)};
         auto count{get_field<int32_t>(obj, "count")};
         auto snapshot_id{get_field<uint64_t>(obj, "snapshot_id")};
         auto params{KvsParameters::from_json(input)};
 
         // Create snapshots.
-        for (int32_t i{0}; i < count; ++i) {
+        for (int32_t i{0}; i < count; ++i)
+        {
             auto kvs{kvs_instance(params)};
             auto set_result{kvs.set_value("counter", KvsValue{i})};
-            if (!set_result) {
+            if (!set_result)
+            {
                 throw std::runtime_error{"Failed to set value"};
             }
 
             // Flush KVS.
             auto flush_result{kvs.flush()};
-            if (!flush_result) {
+            if (!flush_result)
+            {
                 throw std::runtime_error{"Failed to flush"};
             }
         }
@@ -165,12 +192,13 @@ class SnapshotRestore : public Scenario {
 
             auto restore_result{kvs.snapshot_restore(snapshot_id)};
             TRACING_INFO(kTargetName,
-                         std::pair{std::string{"result"},
-                                   restore_result ? "Ok(())" : "Err(InvalidSnapshotId)"});
+                         std::pair{std::string{"result"}, restore_result ? "Ok(())" : "Err(InvalidSnapshotId)"});
 
-            if (restore_result) {
+            if (restore_result)
+            {
                 auto get_result{kvs.get_value("counter")};
-                if (!get_result) {
+                if (!get_result)
+                {
                     throw std::runtime_error{"Failed to read value"};
                 }
 
@@ -181,13 +209,18 @@ class SnapshotRestore : public Scenario {
     }
 };
 
-class SnapshotPaths : public Scenario {
-   public:
+class SnapshotPaths : public Scenario
+{
+  public:
     ~SnapshotPaths() final = default;
 
-    std::string name() const final { return "paths"; }
+    std::string name() const final
+    {
+        return "paths";
+    }
 
-    void run(const std::string& input) const final {
+    void run(const std::string& input) const final
+    {
         auto obj{get_object(input)};
         auto count{get_field<int32_t>(obj, "count")};
         auto snapshot_id{get_field<uint64_t>(obj, "snapshot_id")};
@@ -196,32 +229,38 @@ class SnapshotPaths : public Scenario {
         auto instance_id{params.instance_id};
 
         // Create snapshots.
-        for (int32_t i{0}; i < count; ++i) {
+        for (int32_t i{0}; i < count; ++i)
+        {
             auto kvs{kvs_instance(params)};
             auto set_result{kvs.set_value("counter", KvsValue{i})};
-            if (!set_result) {
+            if (!set_result)
+            {
                 throw std::runtime_error{"Failed to set value"};
             }
 
             // Flush KVS.
             auto flush_result{kvs.flush()};
-            if (!flush_result) {
+            if (!flush_result)
+            {
                 throw std::runtime_error{"Failed to flush"};
             }
         }
 
         {
             auto [kvs_path, hash_path] = kvs_hash_paths(working_dir, instance_id, snapshot_id);
-            TRACING_INFO(kTargetName, std::make_pair(std::string{"kvs_path"}, kvs_path),
+            TRACING_INFO(kTargetName,
+                         std::make_pair(std::string{"kvs_path"}, kvs_path),
                          std::make_pair(std::string{"hash_path"}, hash_path));
         }
     }
 };
 
-ScenarioGroup::Ptr snapshots_group() {
-    return ScenarioGroup::Ptr{new ScenarioGroupImpl{
-        "snapshots",
-        {std::make_shared<SnapshotCount>(), std::make_shared<SnapshotMaxCount>(),
-         std::make_shared<SnapshotRestore>(), std::make_shared<SnapshotPaths>()},
-        {}}};
+ScenarioGroup::Ptr snapshots_group()
+{
+    return ScenarioGroup::Ptr{new ScenarioGroupImpl{"snapshots",
+                                                    {std::make_shared<SnapshotCount>(),
+                                                     std::make_shared<SnapshotMaxCount>(),
+                                                     std::make_shared<SnapshotRestore>(),
+                                                     std::make_shared<SnapshotPaths>()},
+                                                    {}}};
 }

--- a/tests/cpp_test_scenarios/src/cit/supported_datatypes.cpp
+++ b/tests/cpp_test_scenarios/src/cit/supported_datatypes.cpp
@@ -26,33 +26,37 @@ using namespace score::json;
 
 namespace
 {
-    const std::string kTargetName{"cpp_test_scenarios::supported_datatypes"};
+const std::string kTargetName{"cpp_test_scenarios::supported_datatypes"};
 
-    void info_log(const std::string &keyname)
-    {
-        TRACING_INFO(kTargetName, std::make_pair(std::string("key"), keyname));
-    }
-    void info_log(const std::string &name, const std::string &value)
-    {
-        TRACING_INFO(kTargetName, std::make_pair(std::string(name), value));
-    }
-    void info_log(const std::string &key, const std::string &key_value,
-                  const std::string &value, const std::string &value_json)
-    {
-        TRACING_INFO(kTargetName, std::make_pair(std::string("key"), key_value),
-                     std::make_pair(std::string("value"), value_json));
-    }
-} // namespace
+void info_log(const std::string& keyname)
+{
+    TRACING_INFO(kTargetName, std::make_pair(std::string("key"), keyname));
+}
+void info_log(const std::string& name, const std::string& value)
+{
+    TRACING_INFO(kTargetName, std::make_pair(std::string(name), value));
+}
+void info_log(const std::string& key,
+              const std::string& key_value,
+              const std::string& value,
+              const std::string& value_json)
+{
+    TRACING_INFO(
+        kTargetName, std::make_pair(std::string("key"), key_value), std::make_pair(std::string("value"), value_json));
+}
+}  // namespace
 
 class SupportedDatatypesKeys : public Scenario
 {
-
-public:
+  public:
     ~SupportedDatatypesKeys() final = default;
 
-    std::string name() const final { return "keys"; }
+    std::string name() const final
+    {
+        return "keys";
+    }
 
-    void run(const std::string &input) const final
+    void run(const std::string& input) const final
     {
         // Create KVS instance with provided params.
         KvsParameters params{KvsParameters::from_json(input)};
@@ -60,10 +64,10 @@ public:
 
         std::vector<std::string> keys_to_check = {
             "example",
-            u8"emoji ✅❗😀", // UTF-8 encoded string literal
-            u8"greek ημα"     // UTF-8 encoded string literal
+            u8"emoji ✅❗😀",  // UTF-8 encoded string literal
+            u8"greek ημα"      // UTF-8 encoded string literal
         };
-        for (const auto &s : keys_to_check)
+        for (const auto& s : keys_to_check)
         {
             kvs.set_value(s, KvsValue(nullptr));
         }
@@ -71,15 +75,14 @@ public:
         auto keys_in_kvs = kvs.get_all_keys();
         if (keys_in_kvs.has_value())
         {
-            for (auto const &s : keys_in_kvs.value())
+            for (const auto& s : keys_in_kvs.value())
             {
                 info_log(s);
             }
         }
         else
         {
-            info_log("get_all_keys_error",
-                     std::string(keys_in_kvs.error().Message()));
+            info_log("get_all_keys_error", std::string(keys_in_kvs.error().Message()));
             throw keys_in_kvs.error();
         }
     }
@@ -87,91 +90,88 @@ public:
 
 class SupportedDatatypesValues : public Scenario
 {
-private:
+  private:
     KvsValue value;
 
-    static std::string kvs_value_to_string(const KvsValue &v)
+    static std::string kvs_value_to_string(const KvsValue& v)
     {
         switch (v.getType())
         {
-        case KvsValue::Type::i32:
-            return std::to_string(std::get<int32_t>(v.getValue()));
-        case KvsValue::Type::u32:
-            return std::to_string(std::get<uint32_t>(v.getValue()));
-        case KvsValue::Type::i64:
-            return std::to_string(std::get<int64_t>(v.getValue()));
-        case KvsValue::Type::u64:
-            return std::to_string(std::get<uint64_t>(v.getValue()));
-        case KvsValue::Type::f64:
-        {
-            // Format floating point value with high precision, then remove trailing zeros and dot for minimal JSON representation
-            auto val = std::get<double>(v.getValue());
-            std::ostringstream oss;
-            oss << std::setprecision(15) << val;
-            std::string s = oss.str();
-            // Remove trailing zeros and dot if needed
-            if (auto dot = s.find('.'); dot != std::string::npos)
+            case KvsValue::Type::i32:
+                return std::to_string(std::get<int32_t>(v.getValue()));
+            case KvsValue::Type::u32:
+                return std::to_string(std::get<uint32_t>(v.getValue()));
+            case KvsValue::Type::i64:
+                return std::to_string(std::get<int64_t>(v.getValue()));
+            case KvsValue::Type::u64:
+                return std::to_string(std::get<uint64_t>(v.getValue()));
+            case KvsValue::Type::f64:
             {
-                // Find last non-zero digit after decimal point
-                auto last_nonzero = s.find_last_not_of('0');
-                if (last_nonzero != std::string::npos && last_nonzero > dot)
+                // Format floating point value with high precision, then remove trailing zeros and
+                // dot for minimal JSON representation
+                auto val = std::get<double>(v.getValue());
+                std::ostringstream oss;
+                oss << std::setprecision(15) << val;
+                std::string s = oss.str();
+                // Remove trailing zeros and dot if needed
+                if (auto dot = s.find('.'); dot != std::string::npos)
                 {
-                    s.erase(last_nonzero + 1);
+                    // Find last non-zero digit after decimal point
+                    auto last_nonzero = s.find_last_not_of('0');
+                    if (last_nonzero != std::string::npos && last_nonzero > dot)
+                    {
+                        s.erase(last_nonzero + 1);
+                    }
+                    // Remove dot if it's the last character
+                    if (s.back() == '.')
+                        s.pop_back();
                 }
-                // Remove dot if it's the last character
-                if (s.back() == '.')
-                    s.pop_back();
+                return s;
             }
-            return s;
-        }
-        case KvsValue::Type::Boolean:
-            return std::get<bool>(v.getValue()) ? "true" : "false";
-        case KvsValue::Type::String:
-            return "\"" + std::get<std::string>(v.getValue()) + "\"";
-        case KvsValue::Type::Null:
-            return "null";
-        case KvsValue::Type::Array:
-        {
-            const auto &arr =
-                std::get<std::vector<std::shared_ptr<KvsValue>>>(v.getValue());
-            std::string json = "[";
-            for (size_t i = 0; i < arr.size(); ++i)
+            case KvsValue::Type::Boolean:
+                return std::get<bool>(v.getValue()) ? "true" : "false";
+            case KvsValue::Type::String:
+                return "\"" + std::get<std::string>(v.getValue()) + "\"";
+            case KvsValue::Type::Null:
+                return "null";
+            case KvsValue::Type::Array:
             {
-                const auto &elem = *arr[i];
-                json += "{\"t\":\"" + SupportedDatatypesValues(elem).name() +
-                        "\",\"v\":" + kvs_value_to_string(elem) + "}";
-                if (i + 1 < arr.size())
-                    json += ",";
+                const auto& arr = std::get<std::vector<std::shared_ptr<KvsValue>>>(v.getValue());
+                std::string json = "[";
+                for (size_t i = 0; i < arr.size(); ++i)
+                {
+                    const auto& elem = *arr[i];
+                    json += "{\"t\":\"" + SupportedDatatypesValues(elem).name() +
+                            "\",\"v\":" + kvs_value_to_string(elem) + "}";
+                    if (i + 1 < arr.size())
+                        json += ",";
+                }
+                json += "]";
+                return json;
             }
-            json += "]";
-            return json;
-        }
-        case KvsValue::Type::Object:
-        {
-            const auto &obj =
-                std::get<std::unordered_map<std::string, std::shared_ptr<KvsValue>>>(
-                    v.getValue());
-            std::string json = "{";
-            size_t count = 0;
-            for (const auto &kv : obj)
+            case KvsValue::Type::Object:
             {
-                const auto &elem = *kv.second;
-                json += "\"" + kv.first + "\":{\"t\":\"" +
-                        SupportedDatatypesValues(elem).name() +
-                        "\",\"v\":" + kvs_value_to_string(elem) + "}";
-                if (++count < obj.size())
-                    json += ",";
+                const auto& obj = std::get<std::unordered_map<std::string, std::shared_ptr<KvsValue>>>(v.getValue());
+                std::string json = "{";
+                size_t count = 0;
+                for (const auto& kv : obj)
+                {
+                    const auto& elem = *kv.second;
+                    json += "\"" + kv.first + "\":{\"t\":\"" + SupportedDatatypesValues(elem).name() +
+                            "\",\"v\":" + kvs_value_to_string(elem) + "}";
+                    if (++count < obj.size())
+                        json += ",";
+                }
+                json += "}";
+                return json;
             }
-            json += "}";
-            return json;
-        }
-        default:
-            return "null";
+            default:
+                return "null";
         }
     }
 
-public:
-    explicit SupportedDatatypesValues(const KvsValue &v) : value(v) {}
+  public:
+    explicit SupportedDatatypesValues(const KvsValue& v) : value(v) {}
 
     ~SupportedDatatypesValues() final = default;
 
@@ -179,32 +179,32 @@ public:
     {
         switch (value.getType())
         {
-        case KvsValue::Type::i32:
-            return "i32";
-        case KvsValue::Type::u32:
-            return "u32";
-        case KvsValue::Type::i64:
-            return "i64";
-        case KvsValue::Type::u64:
-            return "u64";
-        case KvsValue::Type::f64:
-            return "f64";
-        case KvsValue::Type::Boolean:
-            return "bool";
-        case KvsValue::Type::String:
-            return "str";
-        case KvsValue::Type::Null:
-            return "null";
-        case KvsValue::Type::Array:
-            return "arr";
-        case KvsValue::Type::Object:
-            return "obj";
-        default:
-            return "unknown";
+            case KvsValue::Type::i32:
+                return "i32";
+            case KvsValue::Type::u32:
+                return "u32";
+            case KvsValue::Type::i64:
+                return "i64";
+            case KvsValue::Type::u64:
+                return "u64";
+            case KvsValue::Type::f64:
+                return "f64";
+            case KvsValue::Type::Boolean:
+                return "bool";
+            case KvsValue::Type::String:
+                return "str";
+            case KvsValue::Type::Null:
+                return "null";
+            case KvsValue::Type::Array:
+                return "arr";
+            case KvsValue::Type::Object:
+                return "obj";
+            default:
+                return "unknown";
         }
     }
 
-    void run(const std::string &input) const final
+    void run(const std::string& input) const final
     {
         // Create KVS instance with provided params.
         KvsParameters params{KvsParameters::from_json(input)};
@@ -219,9 +219,10 @@ public:
         if (kvs_value.has_value())
         {
             // Log key and value as separate fields for Python test compatibility
-            info_log("key", name(), "value",
-                     std::string("{\"t\":\"" + name() + "\",\"v\":" +
-                                 kvs_value_to_string(kvs_value.value()) + "}"));
+            info_log("key",
+                     name(),
+                     "value",
+                     std::string("{\"t\":\"" + name() + "\",\"v\":" + kvs_value_to_string(kvs_value.value()) + "}"));
         }
         else
         {
@@ -232,26 +233,22 @@ public:
     // Factory functions for each value type scenario
     static Scenario::Ptr supported_datatypes_i32()
     {
-        return std::make_shared<SupportedDatatypesValues>(
-            KvsValue(static_cast<int32_t>(-321)));
+        return std::make_shared<SupportedDatatypesValues>(KvsValue(static_cast<int32_t>(-321)));
     }
 
     static Scenario::Ptr supported_datatypes_u32()
     {
-        return std::make_shared<SupportedDatatypesValues>(
-            KvsValue(static_cast<uint32_t>(1234)));
+        return std::make_shared<SupportedDatatypesValues>(KvsValue(static_cast<uint32_t>(1234)));
     }
 
     static Scenario::Ptr supported_datatypes_i64()
     {
-        return std::make_shared<SupportedDatatypesValues>(
-            KvsValue(static_cast<int64_t>(-123456789)));
+        return std::make_shared<SupportedDatatypesValues>(KvsValue(static_cast<int64_t>(-123456789)));
     }
 
     static Scenario::Ptr supported_datatypes_u64()
     {
-        return std::make_shared<SupportedDatatypesValues>(
-            KvsValue(static_cast<uint64_t>(123456789)));
+        return std::make_shared<SupportedDatatypesValues>(KvsValue(static_cast<uint64_t>(123456789)));
     }
 
     static Scenario::Ptr supported_datatypes_f64()
@@ -272,44 +269,40 @@ public:
     static Scenario::Ptr supported_datatypes_array()
     {
         // Compose array value as in Rust
-        std::unordered_map<std::string, KvsValue> obj = {
-            {"sub-number", KvsValue(789.0)}};
-        std::vector<KvsValue> arr =
-            std::vector<KvsValue>{KvsValue(321.5),
-                                  KvsValue(false),
-                                  KvsValue("hello"),
-                                  KvsValue(nullptr),
-                                  KvsValue(std::vector<KvsValue>{}),
-                                  KvsValue(obj)};
+        std::unordered_map<std::string, KvsValue> obj = {{"sub-number", KvsValue(789.0)}};
+        std::vector<KvsValue> arr = std::vector<KvsValue>{KvsValue(321.5),
+                                                          KvsValue(false),
+                                                          KvsValue("hello"),
+                                                          KvsValue(nullptr),
+                                                          KvsValue(std::vector<KvsValue>{}),
+                                                          KvsValue(obj)};
         return std::make_shared<SupportedDatatypesValues>(KvsValue(arr));
     }
 
     static Scenario::Ptr supported_datatypes_object()
     {
-        std::unordered_map<std::string, KvsValue> obj = {
-            {"sub-number", KvsValue(789.0)}};
+        std::unordered_map<std::string, KvsValue> obj = {{"sub-number", KvsValue(789.0)}};
         return std::make_shared<SupportedDatatypesValues>(KvsValue(obj));
     }
 
     static ScenarioGroup::Ptr value_types_group()
     {
-        std::vector<Scenario::Ptr> scenarios = {
-            supported_datatypes_i32(), supported_datatypes_u32(),
-            supported_datatypes_i64(), supported_datatypes_u64(),
-            supported_datatypes_f64(), supported_datatypes_bool(),
-            supported_datatypes_string(), supported_datatypes_array(),
-            supported_datatypes_object()};
-        return std::make_shared<ScenarioGroupImpl>(
-            "values", scenarios, std::vector<ScenarioGroup::Ptr>{});
+        std::vector<Scenario::Ptr> scenarios = {supported_datatypes_i32(),
+                                                supported_datatypes_u32(),
+                                                supported_datatypes_i64(),
+                                                supported_datatypes_u64(),
+                                                supported_datatypes_f64(),
+                                                supported_datatypes_bool(),
+                                                supported_datatypes_string(),
+                                                supported_datatypes_array(),
+                                                supported_datatypes_object()};
+        return std::make_shared<ScenarioGroupImpl>("values", scenarios, std::vector<ScenarioGroup::Ptr>{});
     }
 };
 
 ScenarioGroup::Ptr supported_datatypes_group()
 {
-    std::vector<Scenario::Ptr> keys = {
-        std::make_shared<SupportedDatatypesKeys>()};
-    std::vector<ScenarioGroup::Ptr> groups = {
-        SupportedDatatypesValues::value_types_group()};
-    return std::make_shared<ScenarioGroupImpl>("supported_datatypes", keys,
-                                               groups);
+    std::vector<Scenario::Ptr> keys = {std::make_shared<SupportedDatatypesKeys>()};
+    std::vector<ScenarioGroup::Ptr> groups = {SupportedDatatypesValues::value_types_group()};
+    return std::make_shared<ScenarioGroupImpl>("supported_datatypes", keys, groups);
 }

--- a/tests/cpp_test_scenarios/src/helpers/helpers.cpp
+++ b/tests/cpp_test_scenarios/src/helpers/helpers.cpp
@@ -14,7 +14,7 @@
 #include "helpers/helpers.hpp"
 #include <sstream>
 
-std::pair<std::string, std::string> kvs_hash_paths(const std::string &working_dir,
+std::pair<std::string, std::string> kvs_hash_paths(const std::string& working_dir,
                                                    score::mw::per::kvs::InstanceId instance_id,
                                                    score::mw::per::kvs::SnapshotId snapshot_id)
 {

--- a/tests/cpp_test_scenarios/src/helpers/helpers.hpp
+++ b/tests/cpp_test_scenarios/src/helpers/helpers.hpp
@@ -16,6 +16,6 @@
 #include <string>
 #include <utility>
 
-std::pair<std::string, std::string> kvs_hash_paths(const std::string &working_dir,
+std::pair<std::string, std::string> kvs_hash_paths(const std::string& working_dir,
                                                    score::mw::per::kvs::InstanceId instance_id,
                                                    score::mw::per::kvs::SnapshotId snapshot_id);

--- a/tests/cpp_test_scenarios/src/helpers/kvs_instance.cpp
+++ b/tests/cpp_test_scenarios/src/helpers/kvs_instance.cpp
@@ -14,7 +14,7 @@
 #include "helpers/kvs_instance.hpp"
 #include <kvsbuilder.hpp>
 
-score::mw::per::kvs::Kvs kvs_instance(const KvsParameters &params)
+score::mw::per::kvs::Kvs kvs_instance(const KvsParameters& params)
 {
     using namespace score::mw::per::kvs;
     InstanceId instance_id{params.instance_id};

--- a/tests/cpp_test_scenarios/src/helpers/kvs_instance.hpp
+++ b/tests/cpp_test_scenarios/src/helpers/kvs_instance.hpp
@@ -14,4 +14,4 @@
 
 #include "kvs_parameters.hpp"
 
-score::mw::per::kvs::Kvs kvs_instance(const KvsParameters &params);
+score::mw::per::kvs::Kvs kvs_instance(const KvsParameters& params);

--- a/tests/cpp_test_scenarios/src/helpers/kvs_parameters.cpp
+++ b/tests/cpp_test_scenarios/src/helpers/kvs_parameters.cpp
@@ -18,37 +18,36 @@ using namespace score::json;
 namespace
 {
 
-    /// Deserialize load parameter: "defaults" or "kvs_load".
-    std::optional<bool> deserialize_load_param(const score::json::Object &obj_root,
-                                               const std::string &field_name)
+/// Deserialize load parameter: "defaults" or "kvs_load".
+std::optional<bool> deserialize_load_param(const score::json::Object& obj_root, const std::string& field_name)
+{
+    if (obj_root.find(field_name) != obj_root.end())
     {
-        if (obj_root.find(field_name) != obj_root.end())
+        auto value_str{obj_root.at(field_name).As<std::string>().value().get()};
+        if (value_str.compare("ignored") == 0)
         {
-            auto value_str{obj_root.at(field_name).As<std::string>().value().get()};
-            if (value_str.compare("ignored") == 0)
-            {
-                throw std::runtime_error{"\"ignored\" load parameter is not supported yet"};
-            }
-            else if (value_str.compare("optional") == 0)
-            {
-                return false;
-            }
-            else if (value_str.compare("required") == 0)
-            {
-                return true;
-            }
-            else
-            {
-                throw std::runtime_error{"Unknown load parameter"};
-            }
+            throw std::runtime_error{"\"ignored\" load parameter is not supported yet"};
         }
-
-        return {};
+        else if (value_str.compare("optional") == 0)
+        {
+            return false;
+        }
+        else if (value_str.compare("required") == 0)
+        {
+            return true;
+        }
+        else
+        {
+            throw std::runtime_error{"Unknown load parameter"};
+        }
     }
 
-} // namespace
+    return {};
+}
 
-KvsParameters KvsParameters::from_json(const std::string &json_str)
+}  // namespace
+
+KvsParameters KvsParameters::from_json(const std::string& json_str)
 {
     // Load and parse provided JSON stirng.
     JsonParser parser;
@@ -61,11 +60,11 @@ KvsParameters KvsParameters::from_json(const std::string &json_str)
     return KvsParameters::from_object(any_res.value().As<Object>().value().get());
 }
 
-KvsParameters KvsParameters::from_object(const Object &object)
+KvsParameters KvsParameters::from_object(const Object& object)
 {
     // Take "kvs_parameters" field containing object.
-    const auto &map_root{object.at("kvs_parameters")};
-    const auto &obj_root{map_root.As<Object>().value().get()};
+    const auto& map_root{object.at("kvs_parameters")};
+    const auto& obj_root{map_root.As<Object>().value().get()};
 
     KvsParameters params{.instance_id = obj_root.at("instance_id").As<uint64_t>().value()};
 

--- a/tests/cpp_test_scenarios/src/helpers/kvs_parameters.hpp
+++ b/tests/cpp_test_scenarios/src/helpers/kvs_parameters.hpp
@@ -18,11 +18,11 @@ struct KvsParameters
 {
     /// Parse `KvsParameters` from JSON string.
     /// JSON is expected to contain `kvs_parameters` field.
-    static KvsParameters from_json(const std::string &json_str);
+    static KvsParameters from_json(const std::string& json_str);
 
     /// Parse `KvsParameters` from `Object`.
     /// `Object` is expected to contain `kvs_parameters` field.
-    static KvsParameters from_object(const score::json::Object &object);
+    static KvsParameters from_object(const score::json::Object& object);
 
     score::mw::per::kvs::InstanceId instance_id;
     std::optional<bool> need_defaults;

--- a/tests/cpp_test_scenarios/src/main.cpp
+++ b/tests/cpp_test_scenarios/src/main.cpp
@@ -22,7 +22,7 @@
 #include "cit/cit.hpp"
 #include "test_basic.hpp"
 
-int main(int argc, char **argv)
+int main(int argc, char** argv)
 {
     try
     {
@@ -42,7 +42,7 @@ int main(int argc, char **argv)
         TestContext test_context{root_group};
         run_cli_app(raw_arguments, test_context);
     }
-    catch (const std::exception &ex)
+    catch (const std::exception& ex)
     {
         std::cerr << ex.what() << std::endl;
         // Match Rust panic return code.

--- a/tests/cpp_test_scenarios/src/test_basic.cpp
+++ b/tests/cpp_test_scenarios/src/test_basic.cpp
@@ -12,23 +12,27 @@
  ********************************************************************************/
 #include "test_basic.hpp"
 
-#include <cassert>
-#include <iostream>
 #include <kvs.hpp>
 #include <kvsbuilder.hpp>
+#include <cassert>
+#include <iostream>
 #include <unordered_map>
 
-#include <tracing.hpp>
 #include "helpers/kvs_parameters.hpp"
 #include "score/json/json_parser.h"
 #include "score/json/json_writer.h"
 #include "score/result/result.h"
+#include <tracing.hpp>
 
 static const std::string kTargetName{"cpp_test_scenarios::basic::basic"};
 
-std::string BasicScenario::name() const { return "basic"; }
+std::string BasicScenario::name() const
+{
+    return "basic";
+}
 
-void BasicScenario::run(const std::string& input) const {
+void BasicScenario::run(const std::string& input) const
+{
     using namespace score::mw::per::kvs;
 
     // Print and parse parameters.
@@ -39,10 +43,12 @@ void BasicScenario::run(const std::string& input) const {
     // Set builder parameters.
     InstanceId instance_id{params.instance_id};
     KvsBuilder builder{instance_id};
-    if (params.need_defaults.has_value()) {
+    if (params.need_defaults.has_value())
+    {
         builder = builder.need_defaults_flag(*params.need_defaults);
     }
-    if (params.need_kvs.has_value()) {
+    if (params.need_kvs.has_value())
+    {
         builder = builder.need_kvs_flag(*params.need_kvs);
     }
     // TODO: handle dir?
@@ -54,21 +60,25 @@ void BasicScenario::run(const std::string& input) const {
     std::string key{"example_key"};
     std::string value{"example_value"};
     auto set_value_result{kvs.set_value(key, KvsValue{value})};
-    if (!set_value_result) {
+    if (!set_value_result)
+    {
         throw std::runtime_error("Failed to set value");
     }
 
     auto get_value_result{kvs.get_value(key)};
-    if (!get_value_result) {
+    if (!get_value_result)
+    {
         throw std::runtime_error{"Failed to get value"};
     }
     auto stored_kvs_value{get_value_result.value()};
-    if (stored_kvs_value.getType() != KvsValue::Type::String) {
+    if (stored_kvs_value.getType() != KvsValue::Type::String)
+    {
         throw std::runtime_error{"Invalid value type"};
     }
 
     auto stored_value{std::get<std::string>(stored_kvs_value.getValue())};
-    if (stored_value.compare(value) != 0) {
+    if (stored_value.compare(value) != 0)
+    {
         throw std::runtime_error("Value mismatch");
     }
 

--- a/tests/cpp_test_scenarios/src/test_basic.hpp
+++ b/tests/cpp_test_scenarios/src/test_basic.hpp
@@ -17,8 +17,9 @@
 
 #include <scenario.hpp>
 
-class BasicScenario final : public Scenario {
-   public:
+class BasicScenario final : public Scenario
+{
+  public:
     ~BasicScenario() final = default;
 
     std::string name() const final;


### PR DESCRIPTION
- Add `.clang-format` file at the repo root.
- Run `clang-format` over all C++ files.

Resolves #218