### PR TITLE
feat: add public kvs wrapper target for external consumers

### DIFF
--- a/src/cpp/src/BUILD
+++ b/src/cpp/src/BUILD
@@ -53,3 +53,13 @@ cc_library(
         "@score_baselibs//score/result",
     ],
 )
+
+# Public API wrapper — allows external projects to depend on KVS
+cc_library(
+    name = "kvs",                          # the clean public target
+    visibility = ["//visibility:public"],  # open to everyone
+    deps = [
+        ":kvs_cpp",
+        ":kvsvalue",
+    ],
+)


### PR DESCRIPTION
Add a public :kvs cc_library wrapper target to allow external projects to depend on the KVS library without coupling to internal targets directly. This follows the same pattern as score_communication//score/mw/com:com.

Fixes: external consumers getting visibility errors when depending on :kvs_cpp or :kvsvalue directly.