### PR TITLE
Fix visibility of kvs_cpp and kvsvalue

### DIFF
--- a/src/cpp/src/BUILD
+++ b/src/cpp/src/BUILD
@@ -21,8 +21,7 @@ cc_library(
     hdrs = ["kvsvalue.hpp"],
     includes = ["."],
     visibility = [
-        "//:__pkg__",
-        "//src/cpp/src/internal:__pkg__",
+        "//visibility:public",
     ],
 )
 
@@ -41,8 +40,7 @@ cc_library(
     ],
     includes = ["."],
     visibility = [
-        "//:__pkg__",
-        "//tests/test_scenarios/cpp:__pkg__",
+        "//visibility:public",
     ],
     deps = [
         ":kvsvalue",


### PR DESCRIPTION
When trying to build the C++ example following the description at `examples/README.md` as external module, I run into the issue:

```
[...]
ERROR: /home/.../persistency_test/BUILD:1:10: in cc_binary rule //:kvs_example: Visibility error:
target '@@score_persistency+//src/cpp/src:kvs_cpp' is not visible from
target '//:kvs_example'
Recommendation: modify the visibility declaration if you think the dependency is legitimate. For more info see https://bazel.build/concepts/visibility
[...]
```

The library must be publicly visible if an application wants to make use of it.