### PR TITLE
chore: add REPO.bazel and simplify sphinx configuration

### DIFF
--- a/REPO.bazel
+++ b/REPO.bazel
@@ -1,0 +1,26 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# The root `docs()` target globs documentation sources from the repository root
+# (`source_dir = "."`). Unlike `.bazelignore` (which only affects target-pattern
+# expansion such as `//...`), `ignore_directories()` also suppresses `glob()`
+# traversal. Without this, the `**/*` globs follow the `bazel-*` convenience
+# symlinks into the output base / execroot and enumerate the entire external
+# dependency tree, configuring millions of targets and making every Bazel
+# command extremely slow.
+ignore_directories([
+    "bazel-*",
+    "_build",
+    "target",
+    ".venv*",
+])

--- a/conf.py
+++ b/conf.py
@@ -11,38 +11,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-# Configuration file for the Sphinx documentation builder.
-#
-# For the full list of built-in configuration values, see the documentation:
-# https://www.sphinx-doc.org/en/master/usage/configuration.html
-
-
-# -- Project information -----------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
-
-project = "Score Persistency"
+project = "S-CORE Persistency"
 project_url = "https://eclipse-score.github.io/persistency/"
-project_prefix = "PER_"
-author = "S-CORE"
-version = "0.1.0"
-
-# -- General configuration ---------------------------------------------------
-# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
-
 
 extensions = [
-    "sphinx_design",
-    "sphinx_needs",
-    "myst_parser",
-    "sphinxcontrib.plantuml",
-    "score_plantuml",
-    "score_metamodel",
-    "score_draw_uml_funcs",
-    "score_source_code_linker",
-    "score_layout",
+    "score_sphinx_bundle",
 ]
-
-myst_enable_extensions = ["colon_fence"]
 
 include_patterns = [
     "index.rst",
@@ -57,19 +31,7 @@ exclude_patterns = [
     # entries are required to prevent the build from failing.
     "bazel-*",
     ".venv*",
+    "_build",
 ]
-
-# Enable markdown rendering
-source_suffix = {
-    ".rst": "restructuredtext",
-    ".md": "markdown",
-}
-
-templates_path = ["templates"]
-
-
-# Enable numref
-numfig = True
-# needs_builder_filter = ""
 
 required_in_id = ["persistency", "kvs"]


### PR DESCRIPTION
## Summary

Two related improvements to repository documentation configuration:

### Add REPO.bazel with ignore_directories()

The root docs() target globs documentation sources from the repository root (source_dir = "."). Without explicit ignore rules, **/* globs can follow bazel-* convenience symlinks into the output base / execroot and enumerate a very large external dependency tree, which can severely slow Bazel invocations.

ignore_directories() suppresses this glob traversal (whereas .bazelignore only affects target-pattern expansion such as //...).

### Simplify conf.py

Switch to score_sphinx_bundle to simplify Sphinx extension configuration.
