### PR TITLE
chore: update dependent Bazel modules to avoid warnings

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -17,7 +17,7 @@ module(
 
 ## Toolchains (dependencies and config)
 # python
-bazel_dep(name = "rules_python", version = "1.8.3")
+bazel_dep(name = "rules_python", version = "1.8.5")
 
 PYTHON_VERSION = "3.12"
 
@@ -95,7 +95,7 @@ git_override(
 )
 
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1")
-bazel_dep(name = "aspect_rules_lint", version = "2.3.0")
+bazel_dep(name = "aspect_rules_lint", version = "2.5.0")
 
 ## temporary overrides / tools
 # Testing utils dependency.


### PR DESCRIPTION
Recent Bazel output reports dependency warning noise around module metadata alignment. This change updates the module dependency baselines so local and CI runs stay warning-clean and easier to triage when real issues appear.