### PR TITLE
Register Ferrocene Rust toolchain for default build config

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -17,6 +17,8 @@
 common --registry=https://raw.githubusercontent.com/eclipse-score/bazel_registry/main/
 common --registry=https://bcr.bazel.build
 
+common --extra_toolchains=@score_toolchains_rust//toolchains/ferrocene:ferrocene_x86_64_unknown_linux_gnu
+
 # -------------------------------------------------------------------------------
 # Default build flags (all configurations)
 # -------------------------------------------------------------------------------
@@ -33,7 +35,6 @@ build --@score_logging//score/mw/log/flags:KRemote_Logging=False
 # the upstream lint toolchain currently resolves an APE-hosted binary URL that
 # returns 403 during module fetches, which breaks unrelated commands such as
 # `bazel run //:docs`.
-build:lint --extra_toolchains=@score_toolchains_rust//toolchains/ferrocene:ferrocene_x86_64_unknown_linux_gnu
 build:lint --config=per-x86_64-linux
 
 test --test_output=errors
@@ -45,7 +46,6 @@ build:per_shared --incompatible_strict_action_env
 build:per_shared --sandbox_writable_path=/var/tmp
 build:per_shared --host_platform=@score_bazel_platforms//:x86_64-linux
 build:per_shared --extra_toolchains=@score_gcc_x86_64_toolchain//:x86_64-linux-gcc_12.2.0
-build:per_shared --extra_toolchains=@score_toolchains_rust//toolchains/ferrocene:ferrocene_x86_64_unknown_linux_gnu
 
 # -------------------------------------------------------------------------------
 # Config dedicated to host platform CPU:x86_64 and OS:Linux


### PR DESCRIPTION
## Why

Building without an explicit `--config` failed to compile `score_baselibs` Rust code:

```
error[E0658]: use of unstable library feature `non_null_from_ref`
  --> external/score_baselibs+/src/log/score_log_fmt/fmt.rs:74:21
error: `NonNull::<T>::from_ref` is not yet stable as a const fn
```

The default (no-config) build resolved to the stable Rust toolchain shipped by `rules_rust` (1.86.0), where `NonNull::from_ref` is not yet const-stable. The `per-*` configs worked only because they registered the Ferrocene toolchain (Rust 1.94.0-nightly) via `per_shared`, which was selected for exec/tool builds.

## What changed

Moved the Ferrocene Rust toolchain registration from `build:per_shared` to `common` in `.bazelrc`, so it applies to every build — including the default no-config build. This makes the whole repo use one consistent Rust toolchain.

## Impact

Existing matrix still builds:

```
bazel build --config=per-x86_64-linux -- //... && \
bazel build --config=per-x86_64-qnx -- //src/... //tests/... && \
bazel build --config=per-arm64-qnx -- //src/... //tests/...
```

And newly, the plain default build and tests now work:

```
bazel build -- //... && bazel test //:cit_tests
```
