### PR TITLE
fix(ci): update copyright workflow ref to v0.0.2 tag

### DIFF
--- a/.github/workflows/copyright.yml
+++ b/.github/workflows/copyright.yml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright (c) 2024 Contributors to the Eclipse Foundation
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -10,17 +10,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-
 name: Copyright checks
-
+permissions:
+  contents: read
 on:
   pull_request:
     types: [opened, reopened, synchronize]
   merge_group:
     types: [checks_requested]
-
 jobs:
   copyright-check:
-    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
-    with:
-      bazel-target: "run --lockfile_mode=error //:copyright.check"
+    uses: eclipse-score/cicd-workflows/.github/workflows/copyright.yml@v0.0.2


### PR DESCRIPTION
Replaces the pinned commit SHA with the `v0.0.2` semver tag from `eclipse-score/cicd-workflows`. The tag is more readable and easier to track for future updates. The copyright workflow itself has not changed since the previously pinned commit.