### PR TITLE
ci: update bzlmod lock workflow to v0.0.2 and PR-only

### DIFF
--- a/.github/workflows/bzlmod-lock.yml
+++ b/.github/workflows/bzlmod-lock.yml
@@ -18,4 +18,4 @@ on:
     types: [opened, reopened, synchronize]
 jobs:
   bzlmod-lock:
-    uses: eclipse-score/cicd-workflows/.github/workflows/bzlmod-lock-check.yml@v0.0.2
+    uses: eclipse-score/cicd-workflows/.github/workflows/bzlmod-lock-check.yml@93aac16ada7d247bbb6ae926509ddea74cf5213a #v0.0.2

--- a/.github/workflows/bzlmod-lock.yml
+++ b/.github/workflows/bzlmod-lock.yml
@@ -16,13 +16,6 @@ permissions:
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-  merge_group:
-    types: [checks_requested]
-  push:
-    branches:
-      - main
 jobs:
   bzlmod-lock:
-    uses: eclipse-score/cicd-workflows/.github/workflows/bzlmod-lock-check.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
-    with:
-      working-directory: .
+    uses: eclipse-score/cicd-workflows/.github/workflows/bzlmod-lock-check.yml@v0.0.2


### PR DESCRIPTION
## Summary
- update reusable workflow reference to `eclipse-score/cicd-workflows/.github/workflows/bzlmod-lock-check.yml@v0.0.2`
- remove redundant `working-directory: .` input (default is `.`)
- make workflow trigger PR-only by removing `push` and `merge_group`

## Why
- keep workflow aligned with the latest released shared CI workflow
- avoid unnecessary CI runs for events that are not used in this repository setup (main is PR-protected and merge queue is not enabled)
