### PR TITLE
cicd: pin actions/checkout to v4.2.2 to restore fork-PR CIT

### DIFF
--- a/.github/workflows/component_integration_tests.yml
+++ b/.github/workflows/component_integration_tests.yml
@@ -31,14 +31,15 @@ jobs:
     steps:
       - name: Checkout repository (pull_request_target via workflow_call)
         if: ${{ github.event_name == 'pull_request_target' }}
-        uses: actions/checkout@v4
+        # TODO(#349): temporary v4.2.2 pin; remove once secure fork-PR checkout is finalized.
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 
       - name: Checkout repository
         if: ${{ github.event_name != 'pull_request_target' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup Rust build environment
         uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
## Why now

`actions/checkout` v4.4.0 (released ~2026-07-20) backported the `pull_request_target` fork-checkout block from v7.0.0. Because `component_integration_tests.yml` used the floating `actions/checkout@v4` tag, the `cit-tests` job (called from the `pull_request_target` Documentation workflow) started **refusing to check out fork PR code**, producing no `tests-report` and breaking `build-docs` (`Artifact not found for name: tests-report`). This blocks all fork PRs (e.g. #346).

## Change

Pin `actions/checkout` to the pre-block **v4.2.2** (`11bd7190…`) in `component_integration_tests.yml`, matching the rest of the org (`cicd-workflows/tests.yml` @ v4.2.2, `cicd-workflows/docs.yml` @ v6.0.2). This restores fork-PR CI immediately.

## Scope

Temporary mitigation only. The final solution (mandatory `tests-report` + secure fork-PR checkout) is tracked in #349.

Refs #349