### PR TITLE
docs: rename belong_to to satisfied_by

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,8 +40,8 @@ user.bazelrc
 .ruff_cache
 
 # docs:incremental and docs:ide_support build artifacts
-/_build
-docs/ubproject.toml
+_build
+ubproject.toml
 
 # Vale - editorial style guide
 .vale.ini

--- a/score/kvs/docs/requirements/index.rst
+++ b/score/kvs/docs/requirements/index.rst
@@ -34,7 +34,7 @@ Component Requirements
    :derived_from: feat_req__persistency__support_datatype_keys[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall accept keys that consist solely of alphanumeric characters, underscores, or dashes.
@@ -47,7 +47,7 @@ Component Requirements
    :derived_from: feat_req__persistency__support_datatype_keys[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall encode each key as valid UTF-8.
@@ -60,7 +60,7 @@ Component Requirements
    :derived_from: feat_req__persistency__support_datatype_keys[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall guarantee that each key is unique.
@@ -73,7 +73,7 @@ Component Requirements
    :derived_from: feat_req__persistency__support_datatype_keys[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall limit the maximum length of a key to 32 bytes.
@@ -86,7 +86,7 @@ Component Requirements
    :derived_from: feat_req__persistency__support_datatype_value[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall accept only values of the following data types: Number,
@@ -100,7 +100,7 @@ Component Requirements
    :derived_from: feat_req__persistency__support_datatype_value[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall serialize and deserialize all values to and from JSON.
@@ -113,7 +113,7 @@ Component Requirements
    :derived_from: feat_req__persistency__support_datatype_value[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall limit the maximum length of a value to 1024 bytes.
@@ -126,7 +126,7 @@ Component Requirements
    :derived_from: feat_req__persistency__support_datatype_value[version==1],feat_req__persistency__default_values[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall support unset values and shall provide a default value
@@ -140,7 +140,7 @@ Component Requirements
    :derived_from: feat_req__persistency__support_datatype_value[version==1],feat_req__persistency__default_values[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall allow resetting a value to its default if a default is
@@ -154,7 +154,7 @@ Component Requirements
    :derived_from: feat_req__persistency__default_values[version==1],feat_req__persistency__default_value_get[version==1],feat_req__persistency__reset_to_default[version==1],feat_req__persistency__default_value_file[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall accept default values of only permitted value data
@@ -168,7 +168,7 @@ Component Requirements
    :derived_from: feat_req__persistency__default_values[version==1],feat_req__persistency__default_value_get[version==1],feat_req__persistency__reset_to_default[version==1],feat_req__persistency__default_value_file[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall provide an API to retrieve default values.
@@ -181,7 +181,7 @@ Component Requirements
    :derived_from: feat_req__persistency__default_values[version==1],feat_req__persistency__default_value_get[version==1],feat_req__persistency__reset_to_default[version==1],feat_req__persistency__default_value_file[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall allow configuration of default values in code or in a
@@ -195,7 +195,7 @@ Component Requirements
    :derived_from: feat_req__persistency__default_values[version==1],feat_req__persistency__default_value_get[version==1],feat_req__persistency__reset_to_default[version==1],feat_req__persistency__default_value_file[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall secure the configuration file for default values with an
@@ -209,7 +209,7 @@ Component Requirements
    :derived_from: feat_req__persistency__cfg[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall allow configuration of KVS constraints at compile-time
@@ -223,7 +223,7 @@ Component Requirements
    :derived_from: feat_req__persistency__concurrency[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall implement thread-safe mechanisms to enable concurrent
@@ -237,7 +237,7 @@ Component Requirements
    :derived_from: feat_req__persistency__multiple_kvs[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall manage all runtime variables within an instance to
@@ -252,7 +252,7 @@ Component Requirements
    :derived_from: feat_req__persistency__integrity_check[version==1],feat_req__persistency__store_data[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall use the file API and the JSON data format to persist data.
@@ -265,7 +265,7 @@ Component Requirements
    :derived_from: feat_req__persistency__integrity_check[version==1],feat_req__persistency__store_data[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall generate a checksum for each data file and shall store
@@ -279,7 +279,7 @@ Component Requirements
    :derived_from: feat_req__persistency__integrity_check[version==1],feat_req__persistency__load_data[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall verify the checksum when loading data.
@@ -292,7 +292,7 @@ Component Requirements
    :derived_from: feat_req__persistency__integrity_check[version==1],feat_req__persistency__store_data[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall use the file API to persist data.
@@ -305,7 +305,7 @@ Component Requirements
    :derived_from: feat_req__persistency__integrity_check[version==1],feat_req__persistency__store_data[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall use the JSON data format to persist data.
@@ -318,7 +318,7 @@ Component Requirements
    :derived_from: feat_req__persistency__versioning[version==1],feat_req__persistency__update_mechanism[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall not provide built-in versioning.
@@ -331,7 +331,7 @@ Component Requirements
    :derived_from: feat_req__persistency__versioning[version==1],feat_req__persistency__update_mechanism[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall use a JSON file storage format that enables the
@@ -346,7 +346,7 @@ Component Requirements
    :derived_from: feat_req__persistency__snapshot_create[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall create a snapshot each time data is stored.
@@ -359,7 +359,7 @@ Component Requirements
    :derived_from: feat_req__persistency__cfg[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall maintain a configurable maximum number of snapshots.
@@ -372,7 +372,7 @@ Component Requirements
    :derived_from: feat_req__persistency__snapshot_create[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall assign the ID 1 to the newest snapshot and shall increment the IDs of older snapshots accordingly.
@@ -385,7 +385,7 @@ Component Requirements
    :derived_from: feat_req__persistency__snapshot_remove[version==1],feat_req__persistency__snapshot_restore[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall rotate and delete the oldest snapshot when the maximum number is reached.
@@ -398,7 +398,7 @@ Component Requirements
    :derived_from: feat_req__persistency__snapshot_restore[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall allow restoration of a snapshot by its ID.
@@ -411,7 +411,7 @@ Component Requirements
    :derived_from: feat_req__persistency__snapshot_remove[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall allow deletion of individual snapshots.
@@ -424,7 +424,7 @@ Component Requirements
    :derived_from: feat_req__persistency__dev_mode[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall provide an engineering mode that can be enabled during
@@ -438,7 +438,7 @@ Component Requirements
    :derived_from: feat_req__persistency__prod_mode[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall provide a field mode that can be enabled during build
@@ -452,7 +452,7 @@ Component Requirements
    :derived_from: feat_req__persistency__async_api[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall provide an asynchronous API in addition to the standard API.
@@ -465,7 +465,7 @@ Component Requirements
    :derived_from: feat_req__persistency__access_control[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall rely on the underlying filesystem for access and
@@ -480,7 +480,7 @@ Component Requirements
    :derived_from: feat_req__persistency__access_control[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall report any access or permission errors encountered at
@@ -494,7 +494,7 @@ Component Requirements
    :derived_from: feat_req__persistency__async_api[version==1],feat_req__persistency__async_completion[version==1]
    :status: valid
    :version: 1
-   :belongs_to: comp__persistency_kvs[version==1]
+   :satisfied_by: comp__persistency_kvs[version==1]
    :tags: inspected
 
    The component shall provide an API for registering callbacks that are triggered by data change events.


### PR DESCRIPTION
Recent process changes have renamed belong_to to satisfied_by. We need to adapt it locally here, as belong_to will be a hard error in the next docs-as-code version.