### PR TITLE
fix: add `c.this_doc()` to needextend

### DIFF
--- a/score/kvs/docs/requirements/chklst_req_inspection.rst
+++ b/score/kvs/docs/requirements/chklst_req_inspection.rst
@@ -180,3 +180,7 @@ And also the following AoUs in "valid" state and with "inspected" tag set (for t
    :columns: id;status;tags
    :colwidths: 25,25,25
    :sort: title
+
+
+.. needextend:: c.this_doc() and docname is not None
+   :+tags: kvs

--- a/score/kvs/docs/requirements/index.rst
+++ b/score/kvs/docs/requirements/index.rst
@@ -511,5 +511,5 @@ Environmental Requirements
 none
 
 
-.. needextend:: docname is not None and "persistency/kvs/requirements" in docname
+.. needextend:: c.this_doc() and docname is not None
    :+tags: kvs


### PR DESCRIPTION
The future Docs-AS-Code releases will enforce that needextends directives can no longer adapt / change needs that are in a different document, therefore now c.this_doc() has to be in the future in every needextend.

This PR fixes this.